### PR TITLE
Feature/rename instrument

### DIFF
--- a/DictManager.py
+++ b/DictManager.py
@@ -35,8 +35,18 @@ class DictManager(Atom):
 		self.displayList.pop(self.displayList.index(itemLabel))
 
 	def name_changed(self, oldLabel, newLabel):
-		self.itemDict[newLabel] = self.itemDict.pop(oldLabel)
-		self.itemDict[newLabel].label = newLabel
+		# Add copy of changing item
+		self.itemDict[newLabel] = self.itemDict[oldLabel]
+
+		# update display list
+		idx = self.displayList.index(oldLabel)
+		self.displayList[idx] = newLabel
+
+		# remove old label from itemDict list
+		self.itemDict.pop(oldLabel)
+
+		# update label to new label list
+		self.itemDict[newLabel].label = newLabel		
 
 	def update_enable(self, itemLabel, checkState):
 		self.itemDict[itemLabel].enabled = checkState

--- a/DictManager.py
+++ b/DictManager.py
@@ -12,6 +12,7 @@ class DictManager(Atom):
 	displayFilter = Callable() # filter which items to display later
 	possibleItems = List() # a list of classes that can possibly be added to this list
 	displayList = ContainerList()
+	onChangeDelegate = Callable()
 
 	def __init__(self, itemDict={}, displayFilter=lambda x: True, **kwargs):
 		self.displayFilter = displayFilter
@@ -46,7 +47,10 @@ class DictManager(Atom):
 		self.itemDict.pop(oldLabel)
 
 		# update label to new label list
-		self.itemDict[newLabel].label = newLabel		
+		self.itemDict[newLabel].label = newLabel	
+
+		if self.onChangeDelegate is not None:
+			self.onChangeDelegate(oldLabel, newLabel)
 
 	def update_enable(self, itemLabel, checkState):
 		self.itemDict[itemLabel].enabled = checkState

--- a/ExpSettingsGUI.py
+++ b/ExpSettingsGUI.py
@@ -1,3 +1,4 @@
+import h5py
 from atom.api import Atom, Typed, Str, Bool
 
 import enaml
@@ -91,6 +92,11 @@ if __name__ == '__main__':
     from ExpSettingsGUI import ExpSettings
     expSettings= ExpSettings(sweeps=Libraries.sweepLib, instruments=Libraries.instrumentLib,
                      measurements=Libraries.measLib,  channels=Libraries.channelLib)
+
+    # setup on change AWG
+    expSettings.channels
+    expSettings.instruments.AWGs.onChangeDelegate = expSettings.channels.on_awg_change
+    
 
     #If we were passed a scripter file to write to then use it
     parser = argparse.ArgumentParser()

--- a/QGL/Channels.py
+++ b/QGL/Channels.py
@@ -299,6 +299,17 @@ class ChannelLibrary(Atom):
                             if paramName not in ignoreList:
                                 setattr(self.channelDict[chName], paramName, chParams[paramName])
 
+    def on_awg_change(self, oldName, newName):
+        print "Change AWG", oldName, newName
+        for chName in self.channelDict:
+            if (isinstance(self.channelDict[chName], PhysicalMarkerChannel) or
+               isinstance(self.channelDict[chName], PhysicalQuadratureChannel)):
+                awgName, awgChannel = chName.split('-')
+                if awgName == oldName:
+                    newLabel = "{0}-{1}".format(newName,awgChannel)
+                    print "Changing {0} to {1}".format(chName, newLabel)
+                    self.physicalChannelManager.name_changed(chName, newLabel)
+
 
 NewLogicalChannelList = [Qubit, LogicalMarkerChannel, Measurement]
 NewPhysicalChannelList = [PhysicalMarkerChannel, PhysicalQuadratureChannel]

--- a/QGL/ChannelsViews.enaml
+++ b/QGL/ChannelsViews.enaml
@@ -69,7 +69,10 @@ enamldef PhysicalMarkerChannelView(GroupBox): curView:
             items << instrumentLib.AWGs.displayList
             index << instrumentLib.AWGs.displayList.index(chan.AWG.label) if (chan.AWG.label in instrumentLib.AWGs.displayList) else -1
             index ::
-                chan.AWG = instrumentLib[selected_item]
+                if selected_item != '':
+                    chan.AWG = instrumentLib[selected_item]
+                else:
+                    chan.AWG.label = ''
 
 enamldef PhysicalQuadratureChannelView(GroupBox): curView:
     attr chan
@@ -83,14 +86,20 @@ enamldef PhysicalQuadratureChannelView(GroupBox): curView:
             items << instrumentLib.AWGs.displayList
             index << instrumentLib.AWGs.displayList.index(chan.AWG.label) if (chan.AWG.label in instrumentLib.AWGs.displayList) else -1
             index ::
-                chan.AWG = instrumentLib[selected_item]
+                if selected_item != '':
+                    chan.AWG = instrumentLib[selected_item]
+                else:
+                    chan.AWG.label = ''
         Label:
             text = 'Source'
         ComboBox:
             items << instrumentLib.sources.displayList
             index << instrumentLib.sources.displayList.index(chan.generator.label) if (chan.generator and chan.generator.label in instrumentLib.sources.displayList) else -1
             index ::
-                chan.generator = instrumentLib[selected_item]
+                if selected_item != '':
+                    chan.generator = instrumentLib[selected_item]
+                else:
+                    chan.generator.label = ''
         Label:
             text = 'Delay (s)'
         FloatField:

--- a/QGL/ChannelsViews.enaml
+++ b/QGL/ChannelsViews.enaml
@@ -144,14 +144,20 @@ enamldef LogicalQuadratureView(GroupBox): curView:
             items << channelLib.physicalChannelManager.displayList
             index << channelLib.physicalChannelManager.displayList.index(chan.physChan.label) if (chan.physChan and chan.physChan.label in channelLib.physicalChannelManager.displayList) else -1
             index ::
-                chan.physChan = channelLib[selected_item]
+                if selected_item != '':
+                    chan.physChan = channelLib[selected_item]
+                else:
+                    chan.physChan.label = ''
         Label:
             text = 'Gate Chan.'
         ComboBox:
             items << channelLib.logicalChannelManager.displayList
             index << channelLib.logicalChannelManager.displayList.index(chan.gateChan.label) if (chan.gateChan and chan.gateChan.label in channelLib.logicalChannelManager.displayList) else -1
             index ::
-                chan.gateChan = channelLib[selected_item]
+                if selected_item != '':
+                    chan.gateChan = channelLib[selected_item]
+                else:
+                    chan.gateChan.label = ''
         Looper:
             iterable << sorted(chan.pulseParams.keys())
             Label:


### PR DESCRIPTION
Propagates an instrument name change to the channel library. 
Physical channels of the form awgName-awgChannel will be renamed.
Supports deleting a instrument without breaking channel views.