### PR TITLE
update all instrument properties on JSON changes

### DIFF
--- a/instruments/AWGs.py
+++ b/instruments/AWGs.py
@@ -45,6 +45,16 @@ class AWG(Instrument):
                 jsonDict['chan_{}'.format(ct+1)] = chan
         return jsonDict
 
+    def update_from_jsondict(self, params):
+        for ct in range(self.numChannels):
+            self.channels[ct].label = params['channels'][ct].label
+            self.channels[ct].amplitude = params['channels'][ct].amplitude
+            self.channels[ct].offset = params['channels'][ct].offset
+            self.channels[ct].enabled = params['channels'][ct].enabled
+
+        for p in ['label', 'enabled', 'address', 'isMaster', 'triggerSource', 'triggerInterval', 'samplingRate', 'seqFile', 'seqForce', 'delay']:
+            setattr(self, p, params[p])
+
 class APS(AWG):
     numChannels = Int(default=4)
     miniLLRepeat = Int(0).tag(desc='How many times to repeat each miniLL')

--- a/instruments/AWGs.py
+++ b/instruments/AWGs.py
@@ -6,6 +6,7 @@ from atom.api import Atom, List, Int, Float, Range, Enum, Bool, Constant, Str
 
 from Instrument import Instrument
 
+
 import enaml
 from enaml.qt.qt_application import QtApplication
 
@@ -46,11 +47,21 @@ class AWG(Instrument):
         return jsonDict
 
     def update_from_jsondict(self, params):
+
+        import JSONHelpers # get around circular import
+        decoder = JSONHelpers.LibraryDecoder()
+
         for ct in range(self.numChannels):
-            self.channels[ct].label = params['channels'][ct].label
-            self.channels[ct].amplitude = params['channels'][ct].amplitude
-            self.channels[ct].offset = params['channels'][ct].offset
-            self.channels[ct].enabled = params['channels'][ct].enabled
+            channelParams = params['channels'][ct]
+
+            # if this is still a raw dictionary convert to object
+            if isinstance(channelParams, dict):
+                channelParams = decoder.dict_to_obj(channelParams)
+
+            self.channels[ct].label = channelParams.label
+            self.channels[ct].amplitude = channelParams.amplitude
+            self.channels[ct].offset = channelParams.offset
+            self.channels[ct].enabled = channelParams.enabled
 
         for p in ['label', 'enabled', 'address', 'isMaster', 'triggerSource', 'triggerInterval', 'samplingRate', 'seqFile', 'seqForce', 'delay']:
             setattr(self, p, params[p])

--- a/instruments/AWGs.py
+++ b/instruments/AWGs.py
@@ -48,15 +48,14 @@ class AWG(Instrument):
 
     def update_from_jsondict(self, params):
 
-        import JSONHelpers # get around circular import
-        decoder = JSONHelpers.LibraryDecoder()
-
         for ct in range(self.numChannels):
             channelParams = params['channels'][ct]
 
             # if this is still a raw dictionary convert to object
             if isinstance(channelParams, dict):
-                channelParams = decoder.dict_to_obj(channelParams)
+                channelParams.pop('x__class__', None)
+                channelParams.pop('x__module__', None)
+                channelParams = AWGChannel(**channelParams)
 
             self.channels[ct].label = channelParams.label
             self.channels[ct].amplitude = channelParams.amplitude

--- a/instruments/Digitizers.py
+++ b/instruments/Digitizers.py
@@ -91,6 +91,21 @@ class X6(Instrument):
 
 		return jsonDict
 
+	def update_from_jsondict(self, params):
+
+		for chName, chParams in params['channels'].items():
+			# if this is still a raw dictionary convert to object
+			if isinstance(chParams, dict):
+				chParams.pop('x__class__', None)
+				chParams.pop('x__module__', None)
+				chParams = X6VirtualChannel(**chParams)
+
+			for paramName in chParams.__getstate__().keys():
+				setattr(self.channels[chName], paramName, getattr(chParams, paramName))
+
+		params.pop('channels')
+		super(X6, self).update_from_jsondict(params)
+
 if __name__ == "__main__":
 	from Digitizers import X6
 	digitizer = X6(label='scope')

--- a/instruments/Instrument.py
+++ b/instruments/Instrument.py
@@ -22,5 +22,7 @@ class Instrument(Atom):
 		return jsonDict
 
 	def update_from_jsondict(self, jsonDict):
+		jsonDict.pop('x__class__', None)
+		jsonDict.pop('x__module__', None)
 		for label,value in jsonDict.items():
 			setattr(self, label, value)

--- a/instruments/InstrumentManager.py
+++ b/instruments/InstrumentManager.py
@@ -92,11 +92,16 @@ class InstrumentLibrary(Atom):
                     print('Failed to update instrument library from file.  Probably just half-written.')
                     return
                 for instrName, instrParams in allParams.items():
-                    if instrName in self.instrDict:
-                        #Update AWG offsets'
-                        if isinstance(self.instrDict[instrName], AWGs.AWG):
-                            for ct in range(self.instrDict[instrName].numChannels):
-                                self.instrDict[instrName].channels[ct].offset = instrParams['channels'][ct]['offset']
+                    if instrName not in self.instrDict:
+                        continue
+                    #Update AWG offsets'
+                    # if isinstance(self.instrDict[instrName], AWGs.AWG):
+                    #     for ct in range(self.instrDict[instrName].numChannels):
+                    #         self.instrDict[instrName].channels[ct].offset = instrParams['channels'][ct]['offset']
+                    # update parameters rather than replacing objects
+                    # Re-encode the strings as ascii (this should go away in Python 3)
+                    instrParams = {k.encode('ascii'):v for k,v in instrParams.items()}
+                    self.instrDict[instrName].update_from_jsondict(instrParams)
 
     def json_encode(self, matlabCompatible=False):
         #When serializing for matlab return only enabled instruments, otherwise all

--- a/instruments/InstrumentManager.py
+++ b/instruments/InstrumentManager.py
@@ -94,11 +94,7 @@ class InstrumentLibrary(Atom):
                 for instrName, instrParams in allParams.items():
                     if instrName not in self.instrDict:
                         continue
-                    #Update AWG offsets'
-                    # if isinstance(self.instrDict[instrName], AWGs.AWG):
-                    #     for ct in range(self.instrDict[instrName].numChannels):
-                    #         self.instrDict[instrName].channels[ct].offset = instrParams['channels'][ct]['offset']
-                    # update parameters rather than replacing objects
+
                     # Re-encode the strings as ascii (this should go away in Python 3)
                     instrParams = {k.encode('ascii'):v for k,v in instrParams.items()}
                     self.instrDict[instrName].update_from_jsondict(instrParams)


### PR DESCRIPTION
Should follow *all* instrument property updates when the underlying JSON file changes (not just AWG offsets).

@caryan 