### PR TITLE
Hotfix/filewatch

### DIFF
--- a/ExpSettingsVal.py
+++ b/ExpSettingsVal.py
@@ -27,7 +27,7 @@ import Libraries
 import QGL.Channels
 
 from QGL.mm import multimethod
-from instruments.AWGs import APS, APS2, Tek5014
+from instruments.AWGs import APS, APS2, Tek5014, AWG
 
 from atom.api import Str
 
@@ -217,6 +217,11 @@ def invalid_awg_name_convention_common(label, channelName, conventionList):
 	if channelName not in conventionList:
 		print errorStr.format(label, channelName, conventionList)
 		return True
+	return False
+
+@multimethod(AWG, unicode)
+def invalid_awg_name_convention(AWG, channelName):
+	# there is no convention for a generic AWG
 	return False
 
 @multimethod(APS, unicode)


### PR DESCRIPTION
Additional features for the Instrument and Channel managers update_from_file to support add, delete, and rename in response to issue #38. A running python instance (ipython console or notebook) will now track these types of changes in the config files. 

Also includes a fit in ExpSettingsVal.py found in test. Adding a Physical Channel without selecting an AWG caused a multimethod dispatch error. 