### PR TITLE
Delayed pulse shapes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 # https://gist.github.com/dan-blanchard/7045057
 
 language: python
-python: 
+python:
   - "2.7"
 
 # Setup anaconda
@@ -14,9 +14,9 @@ before_install:
   - conda update --yes conda
   - travis_retry conda install --yes python=$TRAVIS_PYTHON_VERSION numpy bokeh enaml atom matplotlib h5py ipython scipy
   - pip install coveralls
-  - wget "https://drive.google.com/uc?export=download&id=0BxaPKTZqyVchZEVHZXRHb2tfNHM" -O test_data.tar.gz
+  - wget "https://drive.google.com/uc?export=download&id=0BxaPKTZqyVchWWdOTG9NZW84a1U" -O test_data.tar.gz
   - tar xzvf test_data.tar.gz -C tests/
-  
+
 # use conda to install packages
 install:
  # Coverage packages are on my binstar channel
@@ -24,7 +24,7 @@ install:
   - mkdir awg
 
 # execute scripts
-script: 
+script:
   - coverage run -m unittest discover
 after_script:
   - coveralls

--- a/QGL/APS2Pattern.py
+++ b/QGL/APS2Pattern.py
@@ -434,7 +434,6 @@ def compress_marker(markerLL):
 				and isinstance(seq[idx+1], Compiler.LLWaveform)
 				and seq[idx].key == seq[idx+1].key):
 
-				# TODO: handle repeats != 0 ?
 				seq[idx].length += seq[idx+1].length
 				del seq[idx+1]
 			else:

--- a/QGL/APS2Pattern.py
+++ b/QGL/APS2Pattern.py
@@ -181,6 +181,14 @@ class Instruction(object):
 
 		return out
 
+	def __eq__(self, other):
+		return self.header == other.header and self.payload == other.payload and self.label == other.label
+
+	def __ne__(self, other):
+		return not self == other
+
+	def __hash__(self):
+		return hash((self.header, self.payload, self.label))
 
 	@property
 	def address(self):

--- a/QGL/APS2Pattern.py
+++ b/QGL/APS2Pattern.py
@@ -413,7 +413,7 @@ def create_seq_instructions(seqs, offsets):
 			if entry.length < MIN_ENTRY_LENGTH:
 				continue
 			markerSel = curSeq - 2
-			state = (entry.key != PatternUtils.TAZKey)
+			state = not entry.isZero
 			instructions.append(Marker(markerSel,
 				                       state,
 				                       entry.length,

--- a/QGL/APS2Pattern.py
+++ b/QGL/APS2Pattern.py
@@ -275,7 +275,7 @@ def preprocess(seqs, shapeLib, T):
 	for seq in seqs:
 		PatternUtils.propagate_frame_changes(seq)
 	seqs = PatternUtils.convert_lengths_to_samples(seqs, SAMPLING_RATE)
-	PatternUtils.quantize_phase(seqs, 1.0/2**14)
+	PatternUtils.quantize_phase(seqs, 1.0/2**13)
 	wfLib = build_waveforms(seqs, shapeLib)
 	PatternUtils.correct_mixers(wfLib, T)
 	return seqs, wfLib
@@ -289,7 +289,7 @@ def wf_hash(wf):
 	if wf.isTimeAmp and wf.frequency == 0: # 2nd condition necessary until we support RT SSB
 		return hash((wf.amp, wf.phase))
 	else:
-		return hash((wf.key, wf.amp, wf.phase, wf.length, wf.frequency))
+		return hash((wf.key, wf.amp, round(wf.phase * 2**13), wf.length, wf.frequency))
 
 def build_waveforms(seqs, shapeLib):
 	# apply amplitude, phase, and modulation and add the resulting waveforms to the library

--- a/QGL/APSPattern.py
+++ b/QGL/APSPattern.py
@@ -48,7 +48,7 @@ def preprocess(seqs, shapeLib, T):
 	for seq in seqs:
 		PatternUtils.propagate_frame_changes(seq)
 	seqs = PatternUtils.convert_lengths_to_samples(seqs, SAMPLING_RATE)
-	PatternUtils.quantize_phase(seqs, 1.0/2**14)
+	PatternUtils.quantize_phase(seqs, 1.0/2**13)
 	wfLib = build_waveforms(seqs, shapeLib)
 	PatternUtils.correct_mixers(wfLib, T)
 	for seq in seqs:
@@ -75,7 +75,7 @@ def wf_hash(wf):
 	if wf.isTimeAmp and wf.frequency == 0: # 2nd condition necessary until we support RT SSB
 		return hash((wf.amp, wf.phase))
 	else:
-		return hash((wf.key, wf.amp, wf.phase, wf.length, wf.frequency))
+		return hash((wf.key, wf.amp, round(wf.phase * 2**13), wf.length, wf.frequency))
 
 TAZShape = np.zeros(1, dtype=np.complex)
 TAZKey = hash_pulse(TAZShape)

--- a/QGL/APSPattern.py
+++ b/QGL/APSPattern.py
@@ -48,6 +48,8 @@ def preprocess_APS(miniLL, wfLib):
 	# miniLL = PatternUtils.propagate_frame(miniLL)
 	miniLL = convert_lengths_to_samples(miniLL)
 	build_waveforms(miniLL, wfLib)
+	# T = ... (get correction matrix)
+	# PatternUtils.correct_mixers(wfLib, T)
 	apply_min_pulse_constraints(miniLL, wfLib)
 	return miniLL
 

--- a/QGL/APSPattern.py
+++ b/QGL/APSPattern.py
@@ -273,8 +273,11 @@ def create_LL_data(LLs, offsets, AWGName=''):
 
 	# Do some checking on miniLL lengths
 	seqLengths = np.array([len(miniLL) for miniLL in LLs])
-	assert np.all(seqLengths >= MIN_LL_ENTRY_COUNT), 'Oops! mini LL''s needs to have at least two elements.'
 	assert np.all(seqLengths < MAX_LL_ENTRIES), 'Oops! mini LL''s cannot have length greater than {0}, you have {1} entries'.format(MAX_BANK_SIZE, len(miniLL))
+
+	for miniLL in LLs:
+		while len(miniLL) < MIN_LL_ENTRY_COUNT:
+			miniLL.append(padding_entry(MIN_ENTRY_LENGTH))
 
 	instructions = []
 	waitFlag = False
@@ -340,7 +343,7 @@ def merge_APS_markerData(IQLL, markerLL, markerNum):
 	'''
 	if len(markerLL) == 0:
 		return
-	assert(len(IQLL) <= len(markerLL), "Sequence length mismatch")
+	assert len(IQLL) <= len(markerLL), "Sequence length mismatch"
 	if len(IQLL) < len(markerLL):
 		for ct in range(len(markerLL) - len(IQLL)):
 			IQLL.append([])

--- a/QGL/BlockLabel.py
+++ b/QGL/BlockLabel.py
@@ -1,25 +1,14 @@
 import string
 
 class BlockLabel(object):
-	def __init__(self, label, offset=0):
+	def __init__(self, label):
 		self.label = label
-		self.offset = offset
-
-	def __add__(self, offset):
-		# allows for addition/subtraction of offsets to labeled blocks
-		return BlockLabel(self.label, self.offset + offset)
-
-	def __sub__(self, offset):
-		return self.__add__(-offset)
 
 	def __repr__(self):
 		return self.__str__()
 
 	def __str__(self):
-		if self.offset == 0:
-			return self.label
-		else:
-			return "{0}+{1}".format(self.label, self.offset)
+		return "{0}:".format(self.label)
 
 	def __eq__(self, other):
 		if isinstance(other, self.__class__):
@@ -27,18 +16,20 @@ class BlockLabel(object):
 		return False
 
 	def __hash__(self):
-		return hash(self.label) ^ hash(self.offset)
+		return hash(self.label)
+
+	def promote(self):
+		return self
 
 def label(seq):
-	# label's are attached to the first block in a sequence
-	# make sure we have a PulseBlock
-	seq[0] = seq[0].promote()
-	if seq[0].label == None:
-		seq[0].label = newlabel()
-	return seq[0].label
+	if not isinstance(seq[0], BlockLabel):
+		seq.insert(0, newlabel())
+	return seq[0]
 
 def endlabel(seq):
-	return label(seq) + len(seq)
+	if not isinstance(seq[-1], BlockLabel):
+		seq.append(newlabel())
+	return seq[-1]
 
 def newlabel():
 	label = BlockLabel(asciibase(newlabel.numlabels))

--- a/QGL/BlockLabel.py
+++ b/QGL/BlockLabel.py
@@ -12,8 +12,11 @@ class BlockLabel(object):
 
 	def __eq__(self, other):
 		if isinstance(other, self.__class__):
-			return self.__dict__ == other.__dict__
+			return self.label == other.label
 		return False
+
+	def __ne__(self, other):
+		return not self == other
 
 	def __hash__(self):
 		return hash(self.label)

--- a/QGL/BlockLabel.py
+++ b/QGL/BlockLabel.py
@@ -21,6 +21,10 @@ class BlockLabel(object):
 	def promote(self):
 		return self
 
+	@property
+	def length(self):
+		return 0
+
 def label(seq):
 	if not isinstance(seq[0], BlockLabel):
 		seq.insert(0, newlabel())

--- a/QGL/Channels.py
+++ b/QGL/Channels.py
@@ -100,15 +100,11 @@ class LogicalChannel(Channel):
     '''
     #During initilization we may just have a string reference to the channel
     physChan = Instance((unicode,PhysicalChannel))
-    AWG = Property()
 
     def __init__(self, **kwargs):
         super(LogicalChannel, self).__init__(**kwargs)
         if self.physChan is None:
             self.physChan = PhysicalChannel(label=kwargs['label']+'-phys')
-
-    def _get_AWG(self):
-        return self.physChan.AWG
 
 class PhysicalMarkerChannel(PhysicalChannel):
     '''

--- a/QGL/Cliffords.py
+++ b/QGL/Cliffords.py
@@ -6,6 +6,7 @@ from scipy.linalg import expm
 from numpy import pi
 from itertools import product
 from random import choice
+import operator
 
 from PulsePrimitives import *
 

--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -429,12 +429,15 @@ class LLWaveform(object):
         self.label = label
         if pulse is None:
             self.key = None
+            self.amp = 0
             self.length = 0
             self.phase = 0
             self.frameChange = 0
             self.isTimeAmp = False
         else:
-            self.key = PatternUtils.hash_pulse(pulse.shape)
+            # self.key = PatternUtils.hash_pulse(pulse.shape)
+            self.key = hash(pulse)
+            self.amp = pulse.amp
             self.length = pulse.length
             self.phase = pulse.phase
             self.frameChange = pulse.frameChange
@@ -466,6 +469,12 @@ def create_padding_LL(length=0):
     return tmpLL
 
 def align(label, pulse, blockLength, alignment, cutoff=12):
+    '''
+    Converts a Pulse or a CompositePulses into an aligned sequence of LLWaveforms
+    by injecting padding entries before and/or after such that the resulting sequence
+    duration is `blockLength`.
+        alignment = "left", "right", or "center"
+    '''
     # check for composite pulses
     if hasattr(pulse, 'pulses'):
         entries = [LLWaveform(p) for p in pulse.pulses]

--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -328,9 +328,10 @@ def normalize(seq, channels=None):
 
     # inject Id's for PulseBlocks not containing every channel
     for block in filter(lambda x: isinstance(x, PulseSequencer.PulseBlock), seq):
+        blocklen = block.length
         emptyChannels = channels - set(block.pulses.keys())
         for ch in emptyChannels:
-            block.pulses[ch] = Id(ch, length=0)
+            block.pulses[ch] = Id(ch, length=blocklen)
     return seq
 
 @multimethod(instruments.AWGs.APS, dict, unicode)

--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -187,13 +187,13 @@ def compile_to_hardware(seqs, fileName, suffix='', alignMode="right"):
     '''
 
     #Add the digitizer trigger to measurements
-    # PatternUtils.add_digitizer_trigger(seqs, channelLib['digitizerTrig'])
+    PatternUtils.add_digitizer_trigger(seqs, channelLib['digitizerTrig'])
 
     # Add gating/blanking pulses
-    # PatternUtils.add_gate_pulses(seqs)
+    PatternUtils.add_gate_pulses(seqs)
 
     # Add the slave trigger
-    # PatternUtils.add_slave_trigger(seqs, channelLib['slaveTrig'])
+    PatternUtils.add_slave_trigger(seqs, channelLib['slaveTrig'])
 
     # find channel set at top level to account for individual sequence channel variability
     channels = set([])

--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -408,42 +408,6 @@ def schedule(channel, pulse, blockLength, alignment):
     else: # center
         return [Id(channel, padLength/2)] + pulses + [Id(channel, padLength/2)]
 
-def flatten_and_separate(seq):
-    '''
-    Given a (potentially nested) list of instructions, flatten the list into a
-    main sequence and a (flattened) list of branches
-    '''
-    branchSeqs = []
-    stack = []
-    idx = 0
-    # Walk through the sequence, pruning branches and putting them on a stack
-    while idx < len(seq):
-        node = seq[idx]
-        # 3 possibilities: have a plain node, have a nested list, or have a tuple of lists
-        if isinstance(node, tuple):
-            # treat the first element as the main branch and push the remaining elements on the stack
-            seq[idx:idx+1] = node[0] #insert the first element into seq
-            stack += list(node[1:])
-        elif isinstance(node, list):
-            seq[idx:idx+1] = node
-        else:
-            idx += 1
-
-    while len(stack) > 0:
-        node = stack.pop()
-        # same 3 possibilities as above
-        if isinstance(node, tuple):
-            # make the first element the new top entry on the stack
-            stack += list(node[1:])
-            stack.append(node[0])
-        elif isinstance(node, list):
-            # add list elements back to stack in reverse order (so first element is on "top")
-            stack += node[::-1]
-        else:
-            branchSeqs.append(node)
-
-    return seq, branchSeqs
-
 # from Stack Overflow: http://stackoverflow.com/questions/2158395/flatten-an-irregular-list-of-lists-in-python/2158532#2158532
 def flatten(l):
     for el in l:

--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -176,7 +176,7 @@ def setup_awg_channels(physicalChannels):
     data = {awg.label:get_empty_channel_set(awg) for awg in awgs}
     for awgdata in data.values():
         for chan in awgdata.keys():
-            awgdata[chan] = {'linkList': [], 'wfLib': {}}
+            awgdata[chan] = {'linkList': [], 'wfLib': {}, 'correctionT': np.identity(2)}
     return data
 
 def bundle_wires(physWires, wfs):
@@ -186,6 +186,8 @@ def bundle_wires(physWires, wfs):
         awgChan = 'ch' + awgChan
         awgData[chan.AWG.label][awgChan]['linkList'] = physWires[chan]
         awgData[chan.AWG.label][awgChan]['wfLib'] = wfs[chan]
+        if hasattr(chan, 'correctionT'):
+            awgData[chan.AWG.label][awgChan]['correctionT'] = chan.correctionT
     return awgData
 
 def compile_to_hardware(seqs, fileName, suffix=''):

--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -42,8 +42,6 @@ from mm import multimethod
 channelLib = {}
 instrumentLib = {}
 
-markerWFLib = {PatternUtils.TAZKey:np.zeros(1, dtype=np.bool), PatternUtils.markerHighKey:np.ones(1, dtype=np.bool) }
-
 def map_logical_to_physical(wires):
     # construct a mapping of physical channels to lists of logical channels
     # (there will be more than one logical channel if multiple logical
@@ -416,27 +414,6 @@ def flatten(l):
                 yield sub
         else:
             yield el
-
-def resolve_offsets(seqs):
-    # create symbol look-up table
-    symbols = {}
-    for i, seq in enumerate(seqs):
-        for j, entry in enumerate(seq):
-            if entry.label and entry.label not in symbols:
-                symbols[entry.label] = (i, j)
-    # re-label targets with offsets
-    for seq in seqs:
-        for entry in seq:
-            if hasattr(entry, 'target') and entry.target and entry.target.offset != 0:
-                noOffsetLabel = copy(entry.target)
-                noOffsetLabel.offset = 0
-                baseidx = symbols[noOffsetLabel]
-                targetidx = (baseidx[0], baseidx[1]+entry.target.offset)
-                # targets are allowed to point beyond the end of the current sequence
-                while targetidx[1] >= len(seqs[targetidx[0]]):
-                    targetidx = (targetidx[0]+1, targetidx[1]-len(seqs[targetidx[0]]))
-                    assert targetidx[0] < len(seqs), "invalid target"
-                entry.target = BlockLabel.label(seqs[targetidx[0]][targetidx[1]:])
 
 def validate_linklist_channels(linklistChannels):
     errors = []

--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -44,49 +44,27 @@ instrumentLib = {}
 
 markerWFLib = {PatternUtils.TAZKey:np.zeros(1, dtype=np.bool), PatternUtils.markerHighKey:np.ones(1, dtype=np.bool) }
 
-def get_channel_label(chanKey):
-    ''' Takes in a channel key and returns a channel label '''
-    if type(chanKey) != tuple:
-        return chanKey.label
-    else:
-        return "".join([chan.label for chan in chanKey])
-
-
-def setup_awg_channels(logicalChannels):
-    awgs = set([])
-    for chan in logicalChannels:
-        awgs.add(chan.AWG)
-
-    data = {awg.label:get_empty_channel_set(awg) for awg in awgs}
-    for awgdata in data.values():
-        for chan in awgdata.keys():
-            awgdata[chan] = {'linkList': [], 'wfLib': {PatternUtils.TAZKey: np.zeros(1, dtype=np.complex)}}
-    return data
-
-def map_logical_to_physical(linkLists, wfLib):
-    awgData = setup_awg_channels(linkLists.keys())   
-
+def map_logical_to_physical(wires):
     # construct a mapping of physical channels to lists of logical channels
     # (there will be more than one logical channel if multiple logical
     # channels share a physical channel)
     physicalChannels = {}
-    for logicalChan in linkLists.keys():
-        physChan = channelLib[get_channel_label(logicalChan)].physChan.label
-        physicalChannels[physChan] = physicalChannels.get(physChan, [])
-        physicalChannels[physChan].append(logicalChan)
+    for logicalChan in wires.keys():
+        physChan = logicalChan.physChan
+        if physChan not in physicalChannels:
+            physicalChannels[physChan] = [logicalChan]
+        else:
+            physicalChannels[physChan].append(logicalChan)
 
     # loop through the physical channels
-    for physChan, channels in physicalChannels.items():
-        if len(channels) > 1:
-            chLL, chWf = merge_channels(linkLists, wfLib, channels)
+    physicalWires = {}
+    for physChan, logicalChan in physicalChannels.items():
+        if len(logicalChan) > 1:
+            physicalWires[physChan] = merge_channels(wires, logicalChan)
         else:
-            chLL = linkLists[channels[0]]
-            chWf = wfLib[channels[0]]
+            physicalWires[physChan] = wires[logicalChan[0]]
 
-        awgName, awgChan = physChan.split('-')
-        awgData[awgName]['ch'+awgChan] = {'linkList': chLL, 'wfLib': chWf}
-
-    return awgData
+    return physicalWires
 
 def merge_channels(linkLists, wfLib, channels):
     chan = channels[0]
@@ -155,13 +133,51 @@ def concatenate_entries(entry1, entry2, wfLib):
     newentry.length = len(entry1) + len(entry2)
     return newentry
 
-def channel_delay_map(awgData):
-    chanDelays = {}
-    # loop through all used IQkeys
-    for IQkey in [awgName + '-' + chanName[2:] for awgName, awg in awgData.items() for chanName in awg.keys()]:
-        chan = channelLib[IQkey]
-        chanDelays[IQkey] = chan.delay + chan.AWG.delay
+def generate_waveforms(physicalWires):
+    wfs = {ch : {} for ch in physicalWires.keys()}
+    for ch, wire in physicalWires.items():
+        for pulse in flatten(wire):
+            if not isinstance(pulse, PulseSequencer.Pulse):
+                continue
+            if pulse.hashshape() not in wfs[ch]:
+                wfs[ch][pulse.hashshape()] = pulse.shape
+    return wfs
+
+def pulses_to_waveforms(physicalWires):
+    wireOuts = {ch : [] for ch in physicalWires.keys()}
+    for ch, seqs in physicalWires.items():
+        for seq in seqs:
+            wireOuts[ch].append([])
+            for pulse in seq:
+                if not isinstance(pulse, PulseSequencer.Pulse):
+                    wireOuts[ch][-1].append(pulse)
+                else:
+                    wireOuts[ch][-1].append(Waveform(pulse))
+    return wireOuts
+
+def channel_delay_map(physicalWires):
+    chanDelays = {chan : chan.delay + chan.AWG.delay for chan in physicalWires.keys()}
     return PatternUtils.normalize_delays(chanDelays)
+
+def setup_awg_channels(physicalChannels):
+    awgs = set([])
+    for chan in physicalChannels:
+        awgs.add(chan.AWG)
+
+    data = {awg.label:get_empty_channel_set(awg) for awg in awgs}
+    for awgdata in data.values():
+        for chan in awgdata.keys():
+            awgdata[chan] = {'linkList': [], 'wfLib': {}}
+    return data
+
+def bundle_wires(physWires, wfs):
+    awgData = setup_awg_channels(physWires.keys())
+    for chan in physWires.keys():
+        _, awgChan = chan.label.split('-')
+        awgChan = 'ch' + awgChan
+        awgData[chan.AWG.label][awgChan]['linkList'] = physWires[chan]
+        awgData[chan.AWG.label][awgChan]['wfLib'] = wfs[chan]
+    return awgData
 
 def compile_to_hardware(seqs, fileName, suffix='', alignMode="right"):
     '''
@@ -171,69 +187,51 @@ def compile_to_hardware(seqs, fileName, suffix='', alignMode="right"):
     '''
 
     #Add the digitizer trigger to measurements
-    PatternUtils.add_digitizer_trigger(seqs, channelLib['digitizerTrig'])
+    # PatternUtils.add_digitizer_trigger(seqs, channelLib['digitizerTrig'])
 
     # Add gating/blanking pulses
-    PatternUtils.add_gate_pulses(seqs)
+    # PatternUtils.add_gate_pulses(seqs)
 
     # Add the slave trigger
-    PatternUtils.add_slave_trigger(seqs, channelLib['slaveTrig'])
+    # PatternUtils.add_slave_trigger(seqs, channelLib['slaveTrig'])
 
     # find channel set at top level to account for individual sequence channel variability
     channels = set([])
     for seq in seqs:
         channels |= find_unique_channels(seq)
 
-    #Compile all the pulses/pulseblocks to linklists and waveform libraries
-    linkLists, wfLib = compile_sequences(seqs, channels)
+    #Compile all the pulses/pulseblocks to sequences of pulses and control flow
+    wireSeqs = compile_sequences(seqs, channels)
 
-    if not validate_linklist_channels(linkLists.keys()):
+    if not validate_linklist_channels(wireSeqs.keys()):
         print "Compile to hardware failed"
         return        
 
     # apply gating constraints
-    for chan, LL in linkLists.items():
+    for chan, seq in wireSeqs.items():
         if isinstance(chan, Channels.LogicalMarkerChannel):
-            linkLists[chan] = PatternUtils.apply_gating_constraints(chan.physChan, LL)
+            wireSeqs[chan] = PatternUtils.apply_gating_constraints(chan.physChan, seq)
     # map logical to physical channels
-    awgData = map_logical_to_physical(linkLists, wfLib)
+    physWires = map_logical_to_physical(wireSeqs)
+
+    # generate wf library (base shapes), replacing Pulse objects with Waveforms
+    wfs = generate_waveforms(physWires)
+
+    physWires = pulses_to_waveforms(physWires)
+
     # construct channel delay map
-    chanDelays = channel_delay_map(awgData)
+    delays = channel_delay_map(physWires)
 
-    # for each physical channel need to:
-    # 1) delay
-    # 2) apply SSB if necessary
-    # 3) mixer correct
-    for awgName, data in awgData.items():
-        for chanName, chanData in data.items():
-            if chanData:
-                # construct IQkey using existing convention
-                IQkey = awgName + '-' + chanName[2:]
-                chanObj = channelLib[IQkey]
+    # apply delays
+    for chan, wire in physWires.items():
+        PatternUtils.delay(wire, delays[chan], chan.samplingRate)
 
-                # apply channel delay
-                PatternUtils.delay(chanData['linkList'], chanDelays[IQkey], chanObj.samplingRate)
+    # bundle wires on instruments
+    awgData = bundle_wires(physWires, wfs)
 
-                # For quadrature channels, apply SSB and mixer correction
-                if isinstance(chanObj, Channels.PhysicalQuadratureChannel):
-
-                    #At this point we finally have the timing of all the pulses so we can apply SSB
-                    if hasattr(chanObj, 'SSBFreq') and abs(chanObj.SSBFreq) > 0:
-                        PatternUtils.apply_SSB(chanData['linkList'], chanData['wfLib'], chanObj.SSBFreq, chanObj.samplingRate)
-
-                    PatternUtils.correctMixer(chanData['wfLib'], chanObj.correctionT)
-
-                #Remove unused waveforms
-                compress_wfLib(chanData['linkList'], chanData['wfLib'])
-
-    #Loop back through to fill empty channels and write to file
+    # convert to hardware formats
     fileList = []
     for awgName, data in awgData.items():
-        #If all the channels are empty then do not bother writing the file
-        if all([chan is None for chan in data.values()]):
-            continue
-
-        # convert to hardware formats
         # create the target folder if it does not exist
         targetFolder = os.path.split(os.path.normpath(os.path.join(config.AWGDir, fileName)))[0]
         if not os.path.exists(targetFolder):
@@ -254,130 +252,56 @@ def compile_sequences(seqs, channels=None):
     for seq in seqs:
         if not isinstance(seq[0], ControlFlow.Wait):
             seq.insert(0, ControlFlow.Wait())
-    # last sequence should end with a GOTO back to the first sequence
+    # turn into a loop, by appending GOTO(0) at end of last sequence
     if not isinstance(seqs[-1][-1], ControlFlow.Goto):
         seqs[-1].append(ControlFlow.Goto(label(seqs[0])))
 
     resolve_offsets(seqs)
 
-    wfLib = {}
     # use seqs[0] as prototype in case we were not given a set of channels
-    miniLL, wfLib = compile_sequence(seqs[0], wfLib, channels)
-    linkLists = {chan: [LL] for chan, LL in miniLL.items()}
+    wires = compile_sequence(seqs[0], channels)
+    wireSeqs = {chan: [seq] for chan, seq in wires.items()}
     for seq in seqs[1:]:
-        miniLL, wfLib = compile_sequence(seq, wfLib, channels)
-        for chan in linkLists.keys():
-            linkLists[chan].append(miniLL[chan])
-
+        wires = compile_sequence(seq, channels)
+        for chan in wireSeqs.keys():
+            wireSeqs[chan].append(wires[chan])
 
     #Print a message so for the experiment we know how many sequences there are
     print('Compiled {} sequences.'.format(len(seqs)))
-    return linkLists, wfLib
+    return wireSeqs
 
-def compile_sequence(seq, wfLib={}, channels=None):
+def compile_sequence(seq, channels=None):
     '''
-    Converts a single sequence into a miniLL and waveform library.
-    Returns a single-entry list of a miniLL and the updated wfLib
+    Takes a list of control flow and pulses, and returns aligned blocks
+    separated into individual abstract channels (wires).
     '''
 
     #Find the set of logical channels used here and initialize them
     if not channels:
         channels = find_unique_channels(seq)
 
-    logicalLLs = {}
-    for chan in channels:
-        logicalLLs[chan] = []
-        if chan not in wfLib:
-            if isinstance(chan, Channels.LogicalMarkerChannel):
-                wfLib[chan] = markerWFLib
-            else:
-                wfLib[chan] = {PatternUtils.TAZKey: np.zeros(1, dtype=np.complex)}
-    carriedPhase = {ch: 0 for ch in channels}
+    wires = {chan: [] for chan in channels}
+
     for block in normalize(flatten(seq), channels):
         # control flow instructions just need to broadcast to all channels
         if isinstance(block, ControlFlow.ControlInstruction):
             for chan in channels:
-                logicalLLs[chan] += [copy(block)]
+                wires[chan] += [copy(block)]
             continue
-        # drop length 0 blocks but push frame change onto next non-zero entry
-        if len(block) == 0:
-            carriedPhase = {ch: carriedPhase[ch]+block.pulses[ch].frameChange for ch in channels}
+        # drop length 0 blocks but push frame change onto previous entry
+        if block.length == 0:
+            for chan in channels:
+                if len(wires[chan]) > 0:
+                    wires[chan][-1].frameChange += block.pulses[chan].frameChange
+                else:
+                    warn("Dropping initial frame change")
             continue
         # Align the block
         for chan in channels:
-            # add aligned LL entry(ies) (if the block contains a composite pulse, may get back multiple waveforms and LL entries)
-            wfs, LLentries = align(block.label, block.pulses[chan], len(block), block.alignment)
-            for wf in wfs:
-                if isinstance(chan, Channels.LogicalMarkerChannel):
-                    wf = wf.astype(np.bool)
-                if PatternUtils.hash_pulse(wf) not in wfLib:
-                    wfLib[chan][PatternUtils.hash_pulse(wf)] = wf
-            # Frame changes are then propagated through
-            logicalLLs[chan] += propagate_frame(LLentries, carriedPhase[chan])
-        carriedPhase = {ch: 0 for ch in channels}
+            # add aligned Pulses (if the block contains a composite pulse, may get back multiple pulses)
+            wires[chan] += align(chan, block.label, block.pulses[chan], block.length, block.alignment)
 
-    # loop through again to find phases, frame changes, and SSB modulation for quadrature channels
-    for chan in channels:
-        if not isinstance(chan, (Channels.Qubit, Channels.Measurement)):
-            continue
-        curFrame = 0
-        for entry in logicalLLs[chan]:
-            if isinstance(entry, ControlFlow.ControlInstruction):
-                continue
-            # frame update
-            shape = np.copy(wfLib[chan][entry.key])
-
-            # See if we can turn into a TA pair
-            # fragile: if you buffer a square pulse it will not be constant valued
-            if np.all(shape == shape[0]):
-                entry.isTimeAmp = True
-                shape = shape[:1]
-                # convert near zeros to PatternUtils.TAZKey
-                if abs(shape[0]) < 1e-6:
-                    entry.key = PatternUtils.TAZKey
-
-            #Rotate for phase and frame change (don't rotate zeros...)
-            if entry.key != PatternUtils.TAZKey:
-                shape *= np.exp(1j*(entry.phase+curFrame))
-                shapeHash = PatternUtils.hash_pulse(shape)
-                if shapeHash not in wfLib[chan]:
-                    wfLib[chan][shapeHash] = shape
-                entry.key = shapeHash
-            curFrame += entry.frameChange
-
-    return logicalLLs, wfLib
-
-def propagate_frame(entries, frame):
-    '''
-    Propagates a frame change through a list of LL entries, dropping zero length entries
-    '''
-    # The first LL entry picks up the carried phase.
-    entries[0].phase += frame
-    entries[0].frameChange += frame
-    # then push frame changes from zero length entries forward
-    for prevEntry, thisEntry in zip(entries, entries[1:]):
-        if prevEntry.length == 0:
-            thisEntry.phase += prevEntry.frameChange
-            thisEntry.frameChange += prevEntry.frameChange
-    # then drop zero length entries
-    for ct in reversed(range(len(entries))):
-        if entries[ct].length == 0:
-            del entries[ct]
-    return entries
-
-def compress_wfLib(seqs, wfLib):
-    '''
-    Helper function to remove unused waveforms from the library.
-    '''
-    usedKeys = set([PatternUtils.TAZKey, PatternUtils.markerHighKey])
-    for miniLL in seqs:
-        for entry in miniLL:
-            if isinstance(entry, LLWaveform):
-                usedKeys.add(entry.key)
-
-    unusedKeys = set(wfLib.keys()) - usedKeys
-    for key in unusedKeys:
-        del wfLib[key]
+    return wires
 
 def find_unique_channels(seq):
     channels = set([])
@@ -421,12 +345,13 @@ def write_sequence_file(awg, data, filename):
 def write_sequence_file(awg, data, filename):
     write_APS2_file(data, filename)
 
-class LLWaveform(object):
+class Waveform(object):
     '''
     IQ LL elements for quadrature mod channels.
     '''
     def __init__(self, pulse=None, label=None):
         self.label = label
+        self.frequency = 0
         if pulse is None:
             self.key = None
             self.amp = 0
@@ -436,9 +361,9 @@ class LLWaveform(object):
             self.isTimeAmp = False
         else:
             # self.key = PatternUtils.hash_pulse(pulse.shape)
-            self.key = hash(pulse)
-            self.amp = pulse.amp
-            self.length = pulse.length
+            self.key = pulse.hashshape()
+            self.amp = pulse.shapeParams['amp']
+            self.length = pulse.shapeParams['length']
             self.phase = pulse.phase
             self.frameChange = pulse.frameChange
             self.isTimeAmp = pulse.isTimeAmp
@@ -449,10 +374,10 @@ class LLWaveform(object):
     def __str__(self):
         labelPart = "{0}: ".format(self.label) if self.label else ""
         if self.isTimeAmp:
-            TA = 'HIGH' if self.key != PatternUtils.TAZKey else 'LOW'
-            return labelPart + "LLWaveform-TA(" + TA + ", " + str(self.length) + ")"
+            TA = 'HIGH' if self.shapeParams['amp'] != 0 else 'LOW'
+            return labelPart + "Waveform-TA(" + TA + ", " + str(self.length) + ")"
         else:
-            return labelPart + "LLWaveform(" + self.key[:6] + ", " + str(self.length) + ")"
+            return labelPart + "Waveform(" + str(self.key)[:6] + ", " + str(self.length) + ")"
 
     def __len__(self):
         return self.length
@@ -461,68 +386,33 @@ class LLWaveform(object):
     def isZero(self):
         return self.key == PatternUtils.TAZKey
 
-def create_padding_LL(length=0):
-    tmpLL = LLWaveform()
-    tmpLL.isTimeAmp = True
-    tmpLL.key = PatternUtils.TAZKey
-    tmpLL.length = length
-    return tmpLL
-
-def align(label, pulse, blockLength, alignment, cutoff=12):
+def align(channel, label, pulse, blockLength, alignment):
     '''
-    Converts a Pulse or a CompositePulses into an aligned sequence of LLWaveforms
-    by injecting padding entries before and/or after such that the resulting sequence
+    Converts a Pulse or a CompositePulses into an aligned sequence of Pulses
+    by injecting TAPulses before and/or after such that the resulting sequence
     duration is `blockLength`.
         alignment = "left", "right", or "center"
     '''
-    # check for composite pulses
-    if hasattr(pulse, 'pulses'):
-        entries = [LLWaveform(p) for p in pulse.pulses]
-        entries[0].label = label
-        shapes = [p.shape for p in pulse.pulses]
+    # make everything look like a sequence
+    if isinstance(pulse, PulseSequencer.CompositePulse):
+        pulses = [pulse.pulses]
     else:
-        entries = [LLWaveform(pulse, label)]
-        shapes = [pulse.shape]
+        pulses = [pulse]
+    # TODO: make labels independent objects so that we can inject them
+    if label:
+        pulses.insert(0, Id(channel, 0))
+        pulses[0].label = label
+
     padLength = blockLength - pulse.length
     if padLength == 0:
         # no padding element required
-        return shapes, entries
-    if (padLength < cutoff) and (alignment == "left" or alignment == "right"):
-        # pad the first/last shape on one side
-        if alignment == "left":
-            shapes[-1] = np.hstack((shapes[-1], np.zeros(padLength)))
-            entries[-1].key = PatternUtils.hash_pulse(shapes[-1])
-        else: #right alignment
-            shapes[0] = np.hstack((np.zeros(padLength), shapes[0]))
-            entries[0].key = PatternUtils.hash_pulse(shapes[0])
-    elif (padLength < 2*cutoff and alignment == "center"):
-        # pad the both sides of the shape(s)
-        if len(shapes) == 1:
-            shapes[0] = np.hstack(( np.zeros(np.floor(padLength/2)), shapes[0], np.zeros(np.ceil(padLength/2)) ))
-            entries[0].key = PatternUtils.hash_pulse(shapes[0])
-        else:
-            shapes[0] = np.hstack(( np.zeros(np.floor(padLength/2)), shapes[0]))
-            shapes[-1] = np.hstack(( np.zeroes(np.ceil(padLength/2)), shapes[-1]))
-            entries[0].key = PatternUtils.hash_pulse(shapes[0])
-            entries[-1].key = PatternUtils.hash_pulse(shapes[-1])
-    elif padLength == blockLength:
-        #Here we have a zero-length sequence which just needs to be expanded
-        entries[0].key = PatternUtils.TAZKey
-        entries[0].length = blockLength
-        shapes = [np.zeros(1, dtype=np.complex)]
-    else:
-        #split the entry into the shape and one or more TAZ
-        if alignment == "left":
-            padEntry = create_padding_LL(padLength)
-            entries = entries + [padEntry]
-        elif alignment == "right":
-            padEntry = create_padding_LL(padLength)
-            entries = [padEntry] + entries
-        else:
-            padEntry1 = create_padding_LL(np.floor(padLength/2))
-            padEntry2 = create_padding_LL(np.ceil(padLength/2))
-            entries = [padEntry1] + entries + [padEntry2]
-    return shapes, entries
+        return pulses
+    elif alignment == "left":
+        return pulses + [Id(channel, padLength)]
+    elif alignment == "right":
+        return [Id(channel, padLength)] + pulses
+    else: # center
+        return [Id(channel, padLength/2)] + pulses + [Id(channel, padLength/2)]
 
 def flatten_and_separate(seq):
     '''

--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -391,7 +391,12 @@ class Waveform(object):
             return labelPart + "Waveform(" + str(self.key)[:6] + ", " + str(self.length) + ")"
 
     def __eq__(self, other):
-        return self.__dict__ == other.__dict__
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False
+
+    def __ne__(self, other):
+        return not self == other
 
     def __hash__(self):
         return hash(frozenset(self.__dict__))

--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -143,7 +143,7 @@ def generate_waveforms(physicalWires):
                 continue
             if pulse.hashshape() not in wfs[ch]:
                 if pulse.isTimeAmp:
-                    wfs[ch][pulse.hashshape()] = pulse.shapeParams['amp']
+                    wfs[ch][pulse.hashshape()] = np.array(pulse.shapeParams['amp'], dtype=np.complex)
                 else:
                     wfs[ch][pulse.hashshape()] = pulse.shape
     return wfs

--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -152,7 +152,6 @@ def concatenate_entries(entry1, entry2, wfLib):
         newentry.key = PatternUtils.hash_pulse(wf)
         newentry.frameChange += entry2.frameChange
         wfLib[newentry.key] = wf
-    newentry.repeat = 1
     newentry.length = len(entry1) + len(entry2)
     return newentry
 
@@ -427,7 +426,6 @@ class LLWaveform(object):
     IQ LL elements for quadrature mod channels.
     '''
     def __init__(self, pulse=None, label=None):
-        self.repeat = 1
         self.label = label
         if pulse is None:
             self.key = None
@@ -435,7 +433,6 @@ class LLWaveform(object):
             self.phase = 0
             self.frameChange = 0
             self.isTimeAmp = False
-            self.repeat = 1
         else:
             self.key = PatternUtils.hash_pulse(pulse.shape)
             self.length = pulse.length
@@ -455,7 +452,7 @@ class LLWaveform(object):
             return labelPart + "LLWaveform(" + self.key[:6] + ", " + str(self.length) + ")"
 
     def __len__(self):
-        return self.length*self.repeat
+        return self.length
 
     @property
     def isZero(self):

--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -17,7 +17,6 @@ limitations under the License.
 '''
 import numpy as np
 import os
-import collections
 import itertools
 import operator
 from warnings import warn
@@ -25,6 +24,7 @@ from copy import copy
 
 import config
 import PatternUtils
+from PatternUtils import flatten
 import Channels
 from PulsePrimitives import Id
 import PulseSequencer
@@ -416,15 +416,6 @@ def schedule(channel, pulse, blockLength, alignment):
         return [Id(channel, padLength)] + pulses
     else: # center
         return [Id(channel, padLength/2)] + pulses + [Id(channel, padLength/2)]
-
-# from Stack Overflow: http://stackoverflow.com/questions/2158395/flatten-an-irregular-list-of-lists-in-python/2158532#2158532
-def flatten(l):
-    for el in l:
-        if isinstance(el, collections.Iterable) and not isinstance(el, basestring):
-            for sub in flatten(el):
-                yield sub
-        else:
-            yield el
 
 def validate_linklist_channels(linklistChannels):
     errors = []

--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -300,11 +300,11 @@ def compile_sequence(seq, wfLib={}, channels=None):
             for chan in channels:
                 logicalLLs[chan] += [copy(block)]
             continue
-        # Align the block
         # drop length 0 blocks but push frame change onto next non-zero entry
         if len(block) == 0:
             carriedPhase = {ch: carriedPhase[ch]+block.pulses[ch].frameChange for ch in channels}
             continue
+        # Align the block
         for chan in channels:
             # add aligned LL entry(ies) (if the block contains a composite pulse, may get back multiple waveforms and LL entries)
             wfs, LLentries = align(block.label, block.pulses[chan], len(block), block.alignment)

--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -399,7 +399,7 @@ class Waveform(object):
         return not self == other
 
     def __hash__(self):
-        return hash(frozenset(self.__dict__))
+        return hash(frozenset(self.__dict__.iteritems()))
 
     @property
     def isZero(self):

--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -122,16 +122,16 @@ def concatenate_entries(entry1, entry2):
     newentry = copy(entry1)
     # TA waveforms with the same amplitude can be merged with a just length update
     # otherwise, need to concatenate the pulse shapes
-    if not (entry1.isTimeAmp and entry2.isTimeAmp and entry1.shapeParams['amp'] == entry2.shapeParams['amp'] and entry1.phase == entry2.phase and entry1.frameChange == 0):
+    if not (entry1.isTimeAmp and entry2.isTimeAmp and entry1.shapeParams['amp'] == entry2.shapeParams['amp'] and entry1.phase == (entry1.frameChange + entry2.phase)):
         # otherwise, need to build a closure to stack them
         def stackShapes(**kwargs):
             return np.hstack((entry1.shapeParams['amp'] * np.exp(1j*entry1.phase) * entry1.shape,
-                              entry2.shapeParams['amp'] * np.exp(1j*entry2.phase) * entry2.shape))
+                              entry2.shapeParams['amp'] * np.exp(1j*(entry1.frameChange + entry2.phase)) * entry2.shape))
 
         newentry.isTimeAmp = False
         newentry.shapeParams = {'amp' : 1, 'shapeFun' : stackShapes}
-        newentry.frameChange += entry2.frameChange
         newentry.label = entry1.label + '+' + entry2.label
+    newentry.frameChange += entry2.frameChange
     newentry.length = entry1.length + entry2.length
     return newentry
 

--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -179,11 +179,10 @@ def bundle_wires(physWires, wfs):
         awgData[chan.AWG.label][awgChan]['wfLib'] = wfs[chan]
     return awgData
 
-def compile_to_hardware(seqs, fileName, suffix='', alignMode="right"):
+def compile_to_hardware(seqs, fileName, suffix=''):
     '''
     Compiles 'seqs' to a hardware description and saves it to 'fileName'. Other inputs:
         suffix : string to append to end of fileName (e.g. with fileNames = 'test' and suffix = 'foo' might save to test-APSfoo.h5)
-        alignMode : 'left' or 'right' (default 'left')
     '''
 
     #Add the digitizer trigger to measurements
@@ -294,10 +293,10 @@ def compile_sequence(seq, channels=None):
                 else:
                     warn("Dropping initial frame change")
             continue
-        # Align the block
+        # schedule the block
         for chan in channels:
             # add aligned Pulses (if the block contains a composite pulse, may get back multiple pulses)
-            wires[chan] += align(chan, block.pulses[chan], block.length, block.alignment)
+            wires[chan] += schedule(chan, block.pulses[chan], block.length, block.alignment)
 
     return wires
 
@@ -385,7 +384,7 @@ class Waveform(object):
     def isZero(self):
         return self.key == PatternUtils.TAZKey
 
-def align(channel, pulse, blockLength, alignment):
+def schedule(channel, pulse, blockLength, alignment):
     '''
     Converts a Pulse or a CompositePulses into an aligned sequence of Pulses
     by injecting TAPulses before and/or after such that the resulting sequence

--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -158,7 +158,7 @@ def pulses_to_waveforms(physicalWires):
                     wireOuts[ch][-1].append(pulse)
                 else:
                     wf = Waveform(pulse)
-                    if isinstance(ch, Channels.PhysicalQuadratureChannel):
+                    if hasattr(ch, 'SSBFreq'):
                         # TODO: move frequency information into the abstract channel
                         wf.frequency = ch.SSBFreq
                     wireOuts[ch][-1].append(wf)

--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -142,7 +142,10 @@ def generate_waveforms(physicalWires):
             if not isinstance(pulse, PulseSequencer.Pulse):
                 continue
             if pulse.hashshape() not in wfs[ch]:
-                wfs[ch][pulse.hashshape()] = pulse.shape
+                if pulse.isTimeAmp:
+                    wfs[ch][pulse.hashshape()] = pulse.shapeParams['amp']
+                else:
+                    wfs[ch][pulse.hashshape()] = pulse.shape
     return wfs
 
 def pulses_to_waveforms(physicalWires):
@@ -374,14 +377,14 @@ class Waveform(object):
     def __str__(self):
         labelPart = "{0}: ".format(self.label) if self.label else ""
         if self.isTimeAmp:
-            TA = 'HIGH' if self.shapeParams['amp'] != 0 else 'LOW'
+            TA = 'HIGH' if self.amp != 0 else 'LOW'
             return labelPart + "Waveform-TA(" + TA + ", " + str(self.length) + ")"
         else:
             return labelPart + "Waveform(" + str(self.key)[:6] + ", " + str(self.length) + ")"
 
     @property
     def isZero(self):
-        return self.key == PatternUtils.TAZKey
+        return self.amp == 0
 
 def schedule(channel, pulse, blockLength, alignment):
     '''

--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -592,4 +592,3 @@ def validate_linklist_channels(linklistChannels):
     if errors != []:
         return False
     return True
-        

--- a/QGL/ControlFlow.py
+++ b/QGL/ControlFlow.py
@@ -89,12 +89,17 @@ class ControlInstruction(object):
 		return result
 
 	def __eq__(self, other):
-		# ignore label in equality testing
-		mydict = self.__dict__.copy()
-		otherdict = other.__dict__.copy()
-		mydict.pop('label')
-		otherdict.pop('label')
-		return mydict == otherdict
+		if isinstance(other, self.__class__):
+			# ignore label in equality testing
+			mydict = self.__dict__.copy()
+			otherdict = other.__dict__.copy()
+			mydict.pop('label')
+			otherdict.pop('label')
+			return mydict == otherdict
+		return False
+
+	def __ne__(self, other):
+		return not self == other
 
 	def promote(self):
 		return self

--- a/QGL/ControlFlow.py
+++ b/QGL/ControlFlow.py
@@ -18,17 +18,21 @@ def qwhile(mask, seq):
 def qdowhile(mask, seq):
 	return seq + [CmpEq(mask), Goto(label(seq))]
 
+# caches for sequences and labels
+qfunction_seq = {}
 def qfunction(func):
-	# caches for sequences and labels
-	seq = {}
 	target = {}
 	@wraps(func)
 	def crfunc(*args):
 		if args not in target:
-			seq[args] = func(*args)
-			target[args] = label(seq[args])
-		return [Call(target[args])], seq[args] + [Return()] # TODO: update me to only return seq[args] on first call
+			seq = func(*args) + [Return()]
+			target[args] = label(seq)
+			qfunction_seq[label(seq)] = seq
+		return Call(target[args])
 	return crfunc
+
+def qfunction_specialization(target):
+	return qfunction_seq[target]
 
 @multimethod(int, Pulse)
 def repeat(n, p):

--- a/QGL/ControlFlow.py
+++ b/QGL/ControlFlow.py
@@ -7,7 +7,6 @@ from mm import multimethod
 
 def qif(mask, ifSeq, elseSeq=None):
 	if elseSeq:
-		endlabel(elseSeq) # make sure to populate label of elseSeq before using it
 		return [CmpEq(mask), Goto(label(ifSeq))] + elseSeq + [Goto(endlabel(ifSeq))] + ifSeq
 	else:
 		endlabel(ifSeq)

--- a/QGL/ControlFlow.py
+++ b/QGL/ControlFlow.py
@@ -1,4 +1,4 @@
-from BlockLabel import label, endlabel
+from BlockLabel import newlabel, label, endlabel
 from PulseSequencer import Pulse
 from functools import wraps
 from mm import multimethod
@@ -13,7 +13,9 @@ def qif(mask, ifSeq, elseSeq=None):
 		return [CmpNeq(mask), Goto(endlabel(ifSeq))] + ifSeq
 
 def qwhile(mask, seq):
-	return [CmpNeq(mask), Goto(endlabel(seq))] + seq
+	label1 = newlabel()
+	label2 = newlabel()
+	return [label1, CmpNeq(mask), Goto(label2)] + seq + [Goto(label1), label2]
 
 def qdowhile(mask, seq):
 	return seq + [CmpEq(mask), Goto(label(seq))]

--- a/QGL/ControlFlow.py
+++ b/QGL/ControlFlow.py
@@ -94,9 +94,6 @@ class ControlInstruction(object):
 	def promote(self):
 		return self
 
-	def __len__(self):
-		return self.length
-
 class Goto(ControlInstruction):
 	def __init__(self, target):
 		super(Goto, self).__init__("GOTO", target=target)

--- a/QGL/PatternUtils.py
+++ b/QGL/PatternUtils.py
@@ -198,8 +198,8 @@ def quantize_phase(seqs, precision):
     for entry in flatten(seqs):
         if not isinstance(entry, Compiler.Waveform):
             continue
-        phase = np.mod(int(round(entry.phase/2.0/pi / precision)), int(1/precision))
-        entry.phase = 2*pi*precision*phase
+        phase = np.mod(int(round(entry.phase / precision)), int(round(2*np.pi/precision)))
+        entry.phase = precision*phase
     return seqs
 
 def convert_lengths_to_samples(instructions, samplingRate):

--- a/QGL/PatternUtils.py
+++ b/QGL/PatternUtils.py
@@ -193,13 +193,13 @@ def propagate_frame_changes(seq):
 
 def quantize_phase(seqs, precision):
     '''
-    Quantizes waveform phases with given precision (in fractions of a circle).
+    Quantizes waveform phases with given precision (in radians).
     '''
     for entry in flatten(seqs):
         if not isinstance(entry, Compiler.Waveform):
             continue
-        phase = np.mod(int(round(entry.phase / precision)), int(round(2*np.pi/precision)))
-        entry.phase = precision*phase
+        phase = np.mod(entry.phase, 2*np.pi)
+        entry.phase = precision * round(phase / precision)
     return seqs
 
 def convert_lengths_to_samples(instructions, samplingRate):

--- a/QGL/PatternUtils.py
+++ b/QGL/PatternUtils.py
@@ -202,19 +202,11 @@ def quantize_phase(seqs, precision):
         entry.phase = 2*pi*precision*phase
     return seqs
 
-def compress_wfLib(seqs, wfLib):
-    '''
-    Helper function to remove unused waveforms from the library.
-    '''
-    usedKeys = set()
-    for miniLL in seqs:
-        for entry in miniLL:
-            if isinstance(entry, Compiler.Waveform):
-                usedKeys.add(entry.key)
-
-    unusedKeys = set(wfLib.keys()) - usedKeys
-    for key in unusedKeys:
-        del wfLib[key]
+def convert_lengths_to_samples(instructions, samplingRate):
+    for entry in flatten(instructions):
+        if isinstance(entry, Compiler.Waveform):
+            entry.length = int(round(entry.length * samplingRate))
+    return instructions
 
 # from Stack Overflow: http://stackoverflow.com/questions/2158395/flatten-an-irregular-list-of-lists-in-python/2158532#2158532
 def flatten(l):

--- a/QGL/PatternUtils.py
+++ b/QGL/PatternUtils.py
@@ -19,7 +19,7 @@ from PulseSequencer import Pulse, TAPulse
 from PulsePrimitives import BLANK
 import ControlFlow, BlockLabel, Compiler
 from math import pi
-import hashlib
+import hashlib, collections
 
 def hash_pulse(shape):
     return hashlib.sha1(shape.tostring()).hexdigest()
@@ -255,3 +255,12 @@ def compress_wfLib(seqs, wfLib):
     unusedKeys = set(wfLib.keys()) - usedKeys
     for key in unusedKeys:
         del wfLib[key]
+
+# from Stack Overflow: http://stackoverflow.com/questions/2158395/flatten-an-irregular-list-of-lists-in-python/2158532#2158532
+def flatten(l):
+    for el in l:
+        if isinstance(el, collections.Iterable) and not isinstance(el, basestring):
+            for sub in flatten(el):
+                yield sub
+        else:
+            yield el

--- a/QGL/PatternUtils.py
+++ b/QGL/PatternUtils.py
@@ -99,7 +99,7 @@ def apply_SSB(linkList, wfLib, SSBFreq, samplingRate):
                 entry.key = shapeHash
             curFrame += phaseStep*entry.length
 
-def correctMixer(wfLib, T):
+def correct_mixers(wfLib, T):
     for k, v in wfLib.items():
         # To get the broadcast to work in numpy, need to do the multiplication one row at a time
         iqWF = np.vstack((np.real(v), np.imag(v)))

--- a/QGL/Plotting.py
+++ b/QGL/Plotting.py
@@ -45,21 +45,22 @@ def in_ipynb():
 output_file()
 
 def build_waveforms(seq):
-    import Compiler
-    from Compiler import compile_sequence #import here to avoid circular imports
-    #compile
-    linkList, wfLib = compile_sequence(seq)
+    import PulseSequencer, Compiler #import here to avoid circular imports
+    wires = Compiler.compile_sequence(seq)
+    # import ipdb; ipdb.set_trace()
 
     # build a concatenated waveform for each channel
-    channels = linkList.keys()
+    channels = wires.keys()
     concatShapes = {q: np.array([0], dtype=np.complex128) for q in channels}
     for q in channels:
         # TODO: deal with repeated sections
-        for entry in filter(lambda x: isinstance(x, Compiler.LLWaveform), linkList[q]):
-            if entry.isTimeAmp:
-                concatShapes[q] = np.append(concatShapes[q], wfLib[q][entry.key][0]*np.ones(entry.length))
-            else:
-                concatShapes[q] = np.append(concatShapes[q], wfLib[q][entry.key])
+        frame = 0
+        for pulse in wires[q]:
+            if isinstance(pulse, PulseSequencer.Pulse):
+                shape = np.exp(1j*(frame+pulse.phase)) * pulse.shapeParams['amp'] * pulse.shape
+                frame += pulse.frameChange
+                concatShapes[q] = np.append(concatShapes[q], shape)
+
     # add an extra zero to make things look more normal
     for q in channels:
         concatShapes[q] = np.append(concatShapes[q], 0)  
@@ -67,21 +68,18 @@ def build_waveforms(seq):
 
 
 def plot_waveforms(waveforms, figTitle = ''):
-    AWGFreq = 1.2e9 # TODO: make this independent of sampling rate
-
     channels = waveforms.keys()
      # plot
     plots = []
     for (ct,chan) in enumerate(channels):
         fig = bk.figure(title=figTitle + repr(chan), plot_width=800, plot_height=350, y_range=[-1.05, 1.05])
         waveformToPlot = waveforms[chan]
-        xpts = np.linspace(0,len(waveformToPlot)/AWGFreq/1e-6,len(waveformToPlot))
+        xpts = np.linspace(0,len(waveformToPlot)/chan.physChan.samplingRate/1e-6,len(waveformToPlot))
         fig.line(xpts, np.real(waveformToPlot), color='red')
         fig.line(xpts, np.imag(waveformToPlot), color='blue')
         plots.append(fig)
     bk.show(bk.VBox(*plots))
 
 def show(seq):
-    from Compiler import build_waveforms
     waveforms = build_waveforms(seq)
     plot_waveforms(waveforms)

--- a/QGL/Plotting.py
+++ b/QGL/Plotting.py
@@ -44,7 +44,8 @@ def in_ipynb():
 output_file()
 
 def build_waveforms(seq):
-    from Compiler import compile_sequence
+    import Compiler
+    from Compiler import compile_sequence #import here to avoid circular imports
     #compile
     linkList, wfLib = compile_sequence(seq)
 

--- a/QGL/Plotting.py
+++ b/QGL/Plotting.py
@@ -47,7 +47,6 @@ output_file()
 def build_waveforms(seq):
     import PulseSequencer, Compiler #import here to avoid circular imports
     wires = Compiler.compile_sequence(seq)
-    # import ipdb; ipdb.set_trace()
 
     # build a concatenated waveform for each channel
     channels = wires.keys()

--- a/QGL/Plotting.py
+++ b/QGL/Plotting.py
@@ -22,6 +22,7 @@ limitations under the License.
 
 import os.path, uuid, tempfile
 import bokeh.plotting as bk
+import numpy as np
 
 #Effective global of whether we are interactive plottinn in a notebook or to a
 #static html file

--- a/QGL/PulsePrimitives.py
+++ b/QGL/PulsePrimitives.py
@@ -44,7 +44,7 @@ def _memoize(pulseFunc):
 
 def Id(qubit, *args, **kwargs):
     '''
-    A delay or do-nothing in the form of a pulse i.e. it will take pulseLength+2*bufferTime.
+    A delay or no-op in the form of a pulse.
     Accepts the following pulse signatures:
         Id(qubit, [kwargs])
         Id(qubit, delay, [kwargs])
@@ -62,8 +62,7 @@ def Id(qubit, *args, **kwargs):
     if len(args) > 0 and isinstance(args[0], (int,float)):
         params['length'] = args[0]
 
-    numPts = np.round(params['length']*params['samplingRate'])
-    return TAPulse("Id", qubit, numPts, 0, 0, 0)
+    return TAPulse("Id", qubit, params['length'], 0)
 
 def Xtheta(qubit, amp=0, **kwargs):
     '''  A generic X rotation with a variable amplitude  '''

--- a/QGL/PulsePrimitives.py
+++ b/QGL/PulsePrimitives.py
@@ -134,7 +134,7 @@ def U90(qubit, phase=0, **kwargs):
 
 def U(qubit, phase=0, **kwargs):
     ''' A generic 180 degree rotation with variable phase.  '''
-    return Utheta(qubit, qubit.pulseParams['piAmp'], phase, label="U90", **kwargs)
+    return Utheta(qubit, qubit.pulseParams['piAmp'], phase, label="U", **kwargs)
 
 def arb_axis_drag(qubit, nutFreq, rotAngle=0, polarAngle=0, aziAngle=0, **kwargs):
     """

--- a/QGL/PulsePrimitives.py
+++ b/QGL/PulsePrimitives.py
@@ -24,12 +24,10 @@ from functools import wraps
 
 def overrideDefaults(chan, updateParams):
     '''Helper function to update any parameters passed in and fill in the defaults otherwise.'''
-    #The default parameter list depends on the channel type so pull out of channel
-    #First get the default or updated values
+    # The default parameter list depends on the channel type so pull out of channel
+    # Then update passed values
     paramDict = chan.pulseParams.copy()
     paramDict.update(updateParams)
-    # pull in the samplingRate from the physicalChannel
-    paramDict['samplingRate'] = chan.physChan.samplingRate
     return paramDict
 
 def _memoize(pulseFunc):
@@ -67,88 +65,96 @@ def Id(qubit, *args, **kwargs):
 def Xtheta(qubit, amp=0, **kwargs):
     '''  A generic X rotation with a variable amplitude  '''
     params = overrideDefaults(qubit, kwargs)
-    shape = params['shapeFun'](amp=amp, **params)
-    return Pulse("Xtheta", qubit, shape, 0, 0.0)
+    params['amp'] = amp
+    return Pulse("Xtheta", qubit, params, 0, 0.0)
 
 def Ytheta(qubit, amp=0, **kwargs):
     ''' A generic Y rotation with a variable amplitude '''
     params = overrideDefaults(qubit, kwargs)
-    shape = params['shapeFun'](amp=amp, **params)
-    return Pulse("Ytheta", qubit, shape, pi/2, 0.0)
+    params['amp'] = amp
+    return Pulse("Ytheta", qubit, params, pi/2, 0.0)
 
 def U90(qubit, phase=0, **kwargs):
     ''' A generic 90 degree rotation with variable phase. '''
     params = overrideDefaults(qubit, kwargs)
-    shape = params['shapeFun'](amp=qubit.pulseParams['pi2Amp'], **params)
-    return Pulse("U90", qubit, shape, phase, 0.0)
+    params['amp'] = qubit.pulseParams['pi2Amp']
+    return Pulse("U90", qubit, params, phase, 0.0)
 
 def U(qubit, phase=0, **kwargs):
     ''' A generic 180 degree rotation with variable phase.  '''
     params = overrideDefaults(qubit, kwargs)
-    shape = params['shapeFun'](amp=qubit.pulseParams['piAmp'], **params)
-    return Pulse("U", qubit, shape, phase, 0.0)
+    params['amp'] = qubit.pulseParams['piAmp']
+    return Pulse("U", qubit, params, phase, 0.0)
 
 def Utheta(qubit, amp=0, phase=0, **kwargs):
     '''  A generic rotation with variable amplitude and phase. '''
     params = overrideDefaults(qubit, kwargs)
-    shape = params['shapeFun'](amp=amp, **params)
-    return Pulse("Utheta", qubit, shape, phase, 0.0)
+    params['amp'] = amp
+    return Pulse("Utheta", qubit, params, phase, 0.0)
 
 #Setup the default 90/180 rotations
 # @_memoize
 def X(qubit, **kwargs):
-    shape = qubit.pulseParams['shapeFun'](amp=qubit.pulseParams['piAmp'], **overrideDefaults(qubit, kwargs))
-    return Pulse("X", qubit, shape, 0, 0.0)
+    params = overrideDefaults(qubit, kwargs)
+    params['amp'] = qubit.pulseParams['piAmp']
+    return Pulse("X", qubit, params, 0, 0.0)
 
 # @_memoize
 def X90(qubit, **kwargs):
-    shape = qubit.pulseParams['shapeFun'](amp=qubit.pulseParams['pi2Amp'], **overrideDefaults(qubit, kwargs))
-    return Pulse("X90", qubit, shape, 0, 0.0)
+    params = overrideDefaults(qubit, kwargs)
+    params['amp'] = qubit.pulseParams['pi2Amp']
+    return Pulse("X90", qubit, params, 0, 0.0)
 
 # @_memoize
 def Xm(qubit, **kwargs):
-    shape = qubit.pulseParams['shapeFun'](amp=qubit.pulseParams['piAmp'], **overrideDefaults(qubit, kwargs))
-    return Pulse("Xm", qubit, shape, pi, 0.0)
+    params = overrideDefaults(qubit, kwargs)
+    params['amp'] = qubit.pulseParams['piAmp']
+    return Pulse("Xm", qubit, params, pi, 0.0)
 
 # @_memoize
 def X90m(qubit, **kwargs):
-    shape = qubit.pulseParams['shapeFun'](amp=qubit.pulseParams['pi2Amp'], **overrideDefaults(qubit, kwargs))
-    return Pulse("X90m", qubit, shape, pi, 0.0)
+    params = overrideDefaults(qubit, kwargs)
+    params['amp'] = qubit.pulseParams['pi2Amp']
+    return Pulse("X90m", qubit, params, pi, 0.0)
 
 # @_memoize
 def Y(qubit, **kwargs):
-    shape = qubit.pulseParams['shapeFun'](amp=qubit.pulseParams['piAmp'], **overrideDefaults(qubit, kwargs))
-    return Pulse("Y", qubit, shape, pi/2, 0.0)
+    params = overrideDefaults(qubit, kwargs)
+    params['amp'] = qubit.pulseParams['piAmp']
+    return Pulse("Y", qubit, params, pi/2, 0.0)
 
 # @_memoize
 def Y90(qubit, **kwargs):
-    shape = qubit.pulseParams['shapeFun'](amp=qubit.pulseParams['pi2Amp'], **overrideDefaults(qubit, kwargs))
-    return Pulse("Y90", qubit, shape, pi/2, 0.0)
+    params = overrideDefaults(qubit, kwargs)
+    params['amp'] = qubit.pulseParams['pi2Amp']
+    return Pulse("Y90", qubit, params, pi/2, 0.0)
 
 # @_memoize
 def Ym(qubit, **kwargs):
-    shape = qubit.pulseParams['shapeFun'](amp=qubit.pulseParams['piAmp'], **overrideDefaults(qubit, kwargs))
-    return Pulse("Ym", qubit, shape, -pi/2, 0.0)
+    params = overrideDefaults(qubit, kwargs)
+    params['amp'] = qubit.pulseParams['piAmp']
+    return Pulse("Ym", qubit, params, -pi/2, 0.0)
 
 # @_memoize
 def Y90m(qubit, **kwargs):
-    shape = qubit.pulseParams['shapeFun'](amp=qubit.pulseParams['pi2Amp'], **overrideDefaults(qubit, kwargs))
-    return Pulse("Y90m", qubit, shape, -pi/2, 0.0)
+    params = overrideDefaults(qubit, kwargs)
+    params['amp'] = qubit.pulseParams['pi2Amp']
+    return Pulse("Y90m", qubit, params, -pi/2, 0.0)
 
 # @_memoize
 def Z(qubit, **kwargs):
-    return Pulse("Z", qubit, np.array([], dtype=np.complex128), 0, pi)
+    return TAPulse("Z", qubit, length=0, amp=0, phase=0, frameChange=pi)
 
 # @_memoize
 def Z90(qubit, **kwargs):
-    return Pulse("Z90", qubit, np.array([], dtype=np.complex128), 0, -pi/2)
+    return TAPulse("Z90", qubit, length=0, amp=0, phase=0, frameChange=-pi/2)
 
 # @_memoize
 def Z90m(qubit, **kwargs):
-    return Pulse("Z90m", qubit, np.array([], dtype=np.complex128), 0, pi/2)
+    return TAPulse("Z90m", qubit, length=0, amp=0, phase=0, frameChange=pi/2)
 
 def Ztheta(qubit, angle=0, **kwargs):
-    return Pulse("Ztheta", qubit, np.array([], dtype=np.complex128), 0, -angle)
+    return TAPulse("Z", qubit, length=0, amp=0, phase=0, frameChange=-angle)
 
 def arb_axis_drag(qubit, nutFreq, rotAngle=0, polarAngle=0, aziAngle=0, **kwargs):
     """
@@ -301,9 +307,10 @@ def AC(qubit, cliffNum):
 # @_memoize
 def CNOT(source, target):
     # construct (source, target) channel and pull parameters from there
-    twoQChannel = Channels.QubitFactory(source.label + target.label)
-    shape = twoQChannel.pulseParams['shapeFun'](amp=twoQChannel.pulseParams['piAmp'], **overrideDefaults(twoQChannel, {}))
-    return Pulse("CNOT", (source, target), shape, 0.0, 0.0)
+    channel = Channels.QubitFactory(source.label + target.label)
+    params = overrideDefaults(channel, kwargs)
+    params['amp'] = channel.pulseParams['piAmp']
+    return Pulse("CNOT", (source, target), params, 0.0, 0.0)
 
 def flat_top_gaussian(chan, riseFall, length, amp, phase=0):
     """
@@ -370,59 +377,13 @@ def MEAS(*args, **kwargs):
                 channelName += q.label
         measChan = Channels.MeasFactory(channelName)
         params = overrideDefaults(measChan, kwargs)
-
-        # measurement channels should have just an "amp" parameter
-        measShape = measChan.pulseParams['shapeFun'](**params)
-        #Apply the autodyne frequency
-        timeStep = 1.0/measChan.physChan.samplingRate
-        timePts = np.linspace(0, params['length'], len(measShape))
-        measShape *= np.exp(-1j*2*pi*measChan.autodyneFreq*timePts)
-        return Pulse("MEAS", measChan, measShape, 0.0, 0.0)
+        params['frequency'] = measChan.autodyneFreq
+        params['baseShape'] = params.pop('shapeFun')
+        params['shapeFun'] = PulseShapes.autodyne
+        return Pulse("MEAS", measChan, params, 0.0, 0.0)
 
     return reduce(operator.mul, [create_meas_pulse(qubit) for qubit in args])
-
-
-def MEASmux(*args, **kwargs):
-    '''
-    MEASmux(q1, ...) constructs a measurement pulse block of a measurement
-    with different autodyne frequencies on the same channels
-    It needs a multi-qubit msm't pulse, e.g., M-q1q2.
-    Each pulse has its own parameters (e.g. M-q1).
-    Use tuple-form for joint readout, e.g.
-        MEAS((q1, q2))
-    '''
-    def create_meas_pulse(qubit):
-        if isinstance(qubit, Channels.Qubit):
-            #Deal with single qubit readout channel
-            channelName = "M-" + qubit.label
-        elif isinstance(qubit, tuple):
-            #Deal with joint readout channel and MUX
-            measChanList = [];
-            paramsList = [];
-            lenList = [];
-            channelName = "M-"
-            for q in qubit:
-                channelName += q.label
-                measChanList += [Channels.MeasFactory("M-"+q.label)]
-                paramsList += [overrideDefaults(measChanList[-1], kwargs)]
-                lenList += [len(measChanList[-1].pulseParams['shapeFun'](**paramsList[-1]))]
-        measChan = Channels.MeasFactory(channelName)
-
-        # measurement channels should have just an "amp" parameter
-        timeStep = 1.0/measChan.physChan.samplingRate
-        measShapeSum = np.zeros(max(lenList),dtype=complex);
-        for i,q in enumerate(qubit):
-            measShape = measChanList[i].pulseParams['shapeFun'](**paramsList[i])
-            timePts = np.linspace(0, paramsList[i]['length'], lenList[i])
-            measShape *= np.exp(-1j*2*pi*measChanList[i].autodyneFreq*timePts)
-            measShapeSum += np.array(measShape.tolist()+[0]*(max(lenList)-lenList[i]))
-
-        return Pulse("MEAS", measChan, measShapeSum, 0.0, 0.0)
-
-    return reduce(operator.mul, [create_meas_pulse(qubit) for qubit in args])
-
-
 
 # Gating/blanking pulse primitives
-def BLANK(chan, width):
-    return TAPulse("BLANK", chan.gateChan, width, 1, 0, 0)
+def BLANK(chan, length):
+    return TAPulse("BLANK", chan.gateChan, length, 1, 0, 0)

--- a/QGL/PulsePrimitives.py
+++ b/QGL/PulsePrimitives.py
@@ -62,99 +62,79 @@ def Id(qubit, *args, **kwargs):
 
     return TAPulse("Id", qubit, params['length'], 0)
 
-def Xtheta(qubit, amp=0, **kwargs):
-    '''  A generic X rotation with a variable amplitude  '''
-    params = overrideDefaults(qubit, kwargs)
-    params['amp'] = amp
-    return Pulse("Xtheta", qubit, params, 0, 0.0)
-
-def Ytheta(qubit, amp=0, **kwargs):
-    ''' A generic Y rotation with a variable amplitude '''
-    params = overrideDefaults(qubit, kwargs)
-    params['amp'] = amp
-    return Pulse("Ytheta", qubit, params, pi/2, 0.0)
-
-def U90(qubit, phase=0, **kwargs):
-    ''' A generic 90 degree rotation with variable phase. '''
-    params = overrideDefaults(qubit, kwargs)
-    params['amp'] = qubit.pulseParams['pi2Amp']
-    return Pulse("U90", qubit, params, phase, 0.0)
-
-def U(qubit, phase=0, **kwargs):
-    ''' A generic 180 degree rotation with variable phase.  '''
-    params = overrideDefaults(qubit, kwargs)
-    params['amp'] = qubit.pulseParams['piAmp']
-    return Pulse("U", qubit, params, phase, 0.0)
-
-def Utheta(qubit, amp=0, phase=0, **kwargs):
+# the most generic pulse is Utheta
+def Utheta(qubit, amp=0, phase=0, label='Utheta', **kwargs):
     '''  A generic rotation with variable amplitude and phase. '''
     params = overrideDefaults(qubit, kwargs)
     params['amp'] = amp
-    return Pulse("Utheta", qubit, params, phase, 0.0)
+    return Pulse(label, qubit, params, phase, 0.0)
+
+# generic pulses around X, Y, and Z axes
+def Xtheta(qubit, amp=0, label='Xtheta', **kwargs):
+    '''  A generic X rotation with a variable amplitude  '''
+    return Utheta(qubit, amp, 0, label=label, **kwargs)
+
+def Ytheta(qubit, amp=0, label='Ytheta', **kwargs):
+    ''' A generic Y rotation with a variable amplitude '''
+    return Utheta(qubit, amp, pi/2, label=label, **kwargs)
+
+def Ztheta(qubit, angle=0, label='Ztheta', **kwargs):
+    # special cased because it can be done with a frame update
+    return TAPulse(label, qubit, length=0, amp=0, phase=0, frameChange=-angle)
 
 #Setup the default 90/180 rotations
 # @_memoize
 def X(qubit, **kwargs):
-    params = overrideDefaults(qubit, kwargs)
-    params['amp'] = qubit.pulseParams['piAmp']
-    return Pulse("X", qubit, params, 0, 0.0)
+    return Xtheta(qubit, qubit.pulseParams['piAmp'], label="X", **kwargs)
 
 # @_memoize
 def X90(qubit, **kwargs):
-    params = overrideDefaults(qubit, kwargs)
-    params['amp'] = qubit.pulseParams['pi2Amp']
-    return Pulse("X90", qubit, params, 0, 0.0)
+    return Xtheta(qubit, qubit.pulseParams['pi2Amp'], label="X90", **kwargs)
 
 # @_memoize
 def Xm(qubit, **kwargs):
-    params = overrideDefaults(qubit, kwargs)
-    params['amp'] = qubit.pulseParams['piAmp']
-    return Pulse("Xm", qubit, params, pi, 0.0)
+    return Xtheta(qubit, -qubit.pulseParams['piAmp'], label="Xm", **kwargs)
 
 # @_memoize
 def X90m(qubit, **kwargs):
-    params = overrideDefaults(qubit, kwargs)
-    params['amp'] = qubit.pulseParams['pi2Amp']
-    return Pulse("X90m", qubit, params, pi, 0.0)
+    return Xtheta(qubit, -qubit.pulseParams['pi2Amp'], label="X90m", **kwargs)
 
 # @_memoize
 def Y(qubit, **kwargs):
-    params = overrideDefaults(qubit, kwargs)
-    params['amp'] = qubit.pulseParams['piAmp']
-    return Pulse("Y", qubit, params, pi/2, 0.0)
+    return Ytheta(qubit, qubit.pulseParams['piAmp'], label="Y", **kwargs)
 
 # @_memoize
 def Y90(qubit, **kwargs):
-    params = overrideDefaults(qubit, kwargs)
-    params['amp'] = qubit.pulseParams['pi2Amp']
-    return Pulse("Y90", qubit, params, pi/2, 0.0)
+    return Ytheta(qubit, qubit.pulseParams['pi2Amp'], label="Y90", **kwargs)
 
 # @_memoize
 def Ym(qubit, **kwargs):
-    params = overrideDefaults(qubit, kwargs)
-    params['amp'] = qubit.pulseParams['piAmp']
-    return Pulse("Ym", qubit, params, -pi/2, 0.0)
+    return Ytheta(qubit, -qubit.pulseParams['piAmp'], label="Ym", **kwargs)
 
 # @_memoize
 def Y90m(qubit, **kwargs):
-    params = overrideDefaults(qubit, kwargs)
-    params['amp'] = qubit.pulseParams['pi2Amp']
-    return Pulse("Y90m", qubit, params, -pi/2, 0.0)
+    return Ytheta(qubit, -qubit.pulseParams['pi2Amp'], label="Y90m", **kwargs)
 
 # @_memoize
 def Z(qubit, **kwargs):
-    return TAPulse("Z", qubit, length=0, amp=0, phase=0, frameChange=pi)
+    return Ztheta(qubit, pi, label="Z", **kwargs)
 
 # @_memoize
 def Z90(qubit, **kwargs):
-    return TAPulse("Z90", qubit, length=0, amp=0, phase=0, frameChange=-pi/2)
+    return Ztheta(qubit, pi/2, label="Z90", **kwargs)
 
 # @_memoize
 def Z90m(qubit, **kwargs):
-    return TAPulse("Z90m", qubit, length=0, amp=0, phase=0, frameChange=pi/2)
+    return Ztheta(qubit, -pi/2, label="Z90m", **kwargs)
 
-def Ztheta(qubit, angle=0, **kwargs):
-    return TAPulse("Z", qubit, length=0, amp=0, phase=0, frameChange=-angle)
+# 90/180 degree rotations with control over the rotation axis
+def U90(qubit, phase=0, **kwargs):
+    ''' A generic 90 degree rotation with variable phase. '''
+    return Utheta(qubit, qubit.pulseParams['pi2Amp'], phase, label="U90", **kwargs)
+
+def U(qubit, phase=0, **kwargs):
+    ''' A generic 180 degree rotation with variable phase.  '''
+    return Utheta(qubit, qubit.pulseParams['piAmp'], phase, label="U90", **kwargs)
 
 def arb_axis_drag(qubit, nutFreq, rotAngle=0, polarAngle=0, aziAngle=0, **kwargs):
     """

--- a/QGL/PulsePrimitives.py
+++ b/QGL/PulsePrimitives.py
@@ -285,10 +285,10 @@ def AC(qubit, cliffNum):
 
 ## two-qubit primitivies
 # @_memoize
-def CNOT(source, target):
+def CNOT(source, target, **kwargs):
     # construct (source, target) channel and pull parameters from there
     channel = Channels.QubitFactory(source.label + target.label)
-    params = overrideDefaults(channel, **kwargs)
+    params = overrideDefaults(channel, kwargs)
     params['amp'] = channel.pulseParams['piAmp']
     return Pulse("CNOT", (source, target), params, 0.0, 0.0)
 

--- a/QGL/PulsePrimitives.py
+++ b/QGL/PulsePrimitives.py
@@ -288,7 +288,7 @@ def AC(qubit, cliffNum):
 def CNOT(source, target):
     # construct (source, target) channel and pull parameters from there
     channel = Channels.QubitFactory(source.label + target.label)
-    params = overrideDefaults(channel, kwargs)
+    params = overrideDefaults(channel, **kwargs)
     params['amp'] = channel.pulseParams['piAmp']
     return Pulse("CNOT", (source, target), params, 0.0, 0.0)
 

--- a/QGL/PulseSequencer.py
+++ b/QGL/PulseSequencer.py
@@ -19,7 +19,6 @@ limitations under the License.
 from copy import copy
 import json
 import numpy as np
-import bokeh.plotting as bk
 
 class Pulse(object):
     '''
@@ -217,46 +216,3 @@ def align(pulseBlock, mode="center"):
     pulseBlock = pulseBlock.promote()
     pulseBlock.alignment = mode
     return pulseBlock
-
-AWGFreq = 1.2e9
-
-def build_waveforms(seq):
-    import Compiler
-    from Compiler import compile_sequence #import here to avoid circular imports 
-    #compile
-    linkList, wfLib = compile_sequence(seq)
-
-    # build a concatenated waveform for each channel
-    channels = linkList.keys()
-    concatShapes = {q: np.array([0], dtype=np.complex128) for q in channels}
-    for q in channels:
-        # TODO: deal with repeated sections
-        for entry in filter(lambda x: isinstance(x, Compiler.LLWaveform), linkList[q]):
-            if entry.isTimeAmp:
-                concatShapes[q] = np.append(concatShapes[q], wfLib[q][entry.key][0]*np.ones(entry.length))
-            else:
-                concatShapes[q] = np.append(concatShapes[q], wfLib[q][entry.key])
-    # add an extra zero to make things look more normal
-    for q in channels:
-        concatShapes[q] = np.append(concatShapes[q], 0)  
-    return concatShapes
-
-def plot_waveforms(waveforms, figTitle = ''):
-    channels = waveforms.keys()
-     # plot
-    plots = []
-    for (ct,chan) in enumerate(channels):
-        fig = bk.figure(title=figTitle + repr(chan), plot_width=800, plot_height=350, y_range=[-1.05, 1.05])
-        waveformToPlot = waveforms[chan]
-        xpts = np.linspace(0,len(waveformToPlot)/AWGFreq/1e-6,len(waveformToPlot))
-        fig.line(xpts, np.real(waveformToPlot), color='red')
-        fig.line(xpts, np.imag(waveformToPlot), color='blue')
-        plots.append(fig)
-    bk.show(bk.VBox(*plots))
-
-def show(seq):
-    waveforms = build_waveforms(seq)
-    plot_waveforms(waveforms)
-    
-   
-

--- a/QGL/PulseSequencer.py
+++ b/QGL/PulseSequencer.py
@@ -29,10 +29,11 @@ class Pulse(object):
         shape - numpy array pulse shape
         frameChange - accumulated phase from the pulse
     '''
-    def __init__(self, label, qubits, shape, phase, frameChange):
+    def __init__(self, label, qubits, shapeFun, shapeParams, phase, frameChange):
         self.label = label
         self.qubits = qubits
-        self.shape = shape.astype(np.complex)
+        self.shapeFun = shapeFun
+        self.shapeParams = shapeParams
         self.phase = phase
         self.frameChange = frameChange
         self.isTimeAmp = False
@@ -54,9 +55,14 @@ class Pulse(object):
             raise NameError("Can only concatenate pulses acting on the same channel")
         return CompositePulse([self, other])
 
-    # unary negation inverts the pulse shape and frame change
+    # unary negation inverts the pulse amplitude and frame change
     def __neg__(self):
-        return Pulse(self.label, self.qubits, -self.shape, self.phase, -self.frameChange)
+        shapeParams = copy(self.shapeParams)
+        if hasattr(shapeParams, 'amp'):
+            shapeParams.amp = -shapeParams.amp
+        else:
+            raise NameError("Can only negate a pulse with an 'amp' shape parameter")
+        return Pulse(self.label, self.qubits, self.shapeFun, shapeParams, self.phase, -self.frameChange)
 
     def __mul__(self, other):
         return self.promote()*other.promote()

--- a/QGL/PulseSequencer.py
+++ b/QGL/PulseSequencer.py
@@ -38,7 +38,6 @@ class Pulse(object):
         self.frameChange = frameChange
         self.isTimeAmp = False
         self.TALength = 0
-        self.repeat = 1
 
     def __repr__(self):
         return str(self)
@@ -145,7 +144,7 @@ class CompositePulse(object):
 
     @property
     def length(self):
-        return sum([p.length*p.repeat for p in self.pulses])
+        return sum([p.length for p in self.pulses])
 
     @property
     def frameChange(self):
@@ -231,11 +230,12 @@ def build_waveforms(seq):
     channels = linkList.keys()
     concatShapes = {q: np.array([0], dtype=np.complex128) for q in channels}
     for q in channels:
+        # TODO: deal with repeated sections
         for entry in filter(lambda x: isinstance(x, Compiler.LLWaveform), linkList[q]):
             if entry.isTimeAmp:
-                concatShapes[q] = np.append(concatShapes[q], wfLib[q][entry.key][0]*np.ones(entry.length*entry.repeat))
+                concatShapes[q] = np.append(concatShapes[q], wfLib[q][entry.key][0]*np.ones(entry.length))
             else:
-                concatShapes[q] = np.append(concatShapes[q], np.tile(wfLib[q][entry.key], (1, entry.repeat)) )
+                concatShapes[q] = np.append(concatShapes[q], wfLib[q][entry.key])
     # add an extra zero to make things look more normal
     for q in channels:
         concatShapes[q] = np.append(concatShapes[q], 0)  

--- a/QGL/PulseSequencer.py
+++ b/QGL/PulseSequencer.py
@@ -38,6 +38,7 @@ class Pulse(object):
         else:
             self.qubits = qubits
         self.shapeParams = shapeParams
+        self.amp = shapeParams['amp']
         self.phase = phase
         self.frameChange = frameChange
         self.isTimeAmp = False
@@ -64,11 +65,8 @@ class Pulse(object):
     # unary negation inverts the pulse amplitude and frame change
     def __neg__(self):
         shapeParams = copy(self.shapeParams)
-        if hasattr(shapeParams, 'amp'):
-            shapeParams.amp = -shapeParams.amp
-        else:
-            raise NameError("Can only negate a pulse with an 'amp' shape parameter")
-        return Pulse(self.label, self.qubits, self.shapeFun, shapeParams, self.phase, -self.frameChange)
+        shapeParams['amp'] *= -1
+        return Pulse(self.label, self.qubits, shapeParams, self.phase, -self.frameChange)
 
     def __mul__(self, other):
         return self.promote()*other.promote()

--- a/QGL/PulseSequencer.py
+++ b/QGL/PulseSequencer.py
@@ -130,13 +130,11 @@ class CompositePulse(object):
             return "+".join([str(p) for p in self.pulses])
 
     def __add__(self, other):
+        if self.qubits != other.qubits:
+            raise NameError("Can only concatenate pulses acting on the same channel")
         if hasattr(other, 'pulses'):
-            if self.pulses.keys() != other.pulses.keys():
-                raise NameError("Can only concatenate pulses acting on the same channel")
             return CompositePulse(self.pulses + other.pulses)
         else:
-            if self.pulses.keys() != other.qubits:
-                raise NameError("Can only concatenate pulses acting on the same channel")
             return CompositePulse(self.pulses + [other])
 
     def __mul__(self, other):

--- a/QGL/PulseSequencer.py
+++ b/QGL/PulseSequencer.py
@@ -86,6 +86,11 @@ class Pulse(object):
     def length(self):
         return self.shapeParams['length']
 
+    @length.setter
+    def length(self, value):
+        self.shapeParams['length'] = value
+        return value
+
     @property
     def isZero(self):
         return self.shapeParams['amp'] == 0 or np.all(self.shape == 0)

--- a/QGL/PulseSequencer.py
+++ b/QGL/PulseSequencer.py
@@ -20,7 +20,7 @@ from copy import copy
 import json
 import numpy as np
 
-import Channels, PulseShapes
+import Channels, PulseShapes, operator
 
 class Pulse(object):
     '''

--- a/QGL/PulseSequencer.py
+++ b/QGL/PulseSequencer.py
@@ -71,7 +71,12 @@ class Pulse(object):
         return self.promote()*other.promote()
 
     def __eq__(self, other):
-        return self.__dict__ == other.__dict__
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False
+
+    def __ne__(self, other):
+        return not self == other
 
     def hashshape(self):
         return hash(frozenset(self.shapeParams.iteritems()))
@@ -141,7 +146,12 @@ class CompositePulse(object):
         return self.promote()*other.promote()
 
     def __eq__(self, other):
-        return self.__dict__ == other.__dict__
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+        return False
+
+    def __ne__(self, other):
+        return not self == other
 
     def promote(self):
         # promote a CompositePulse to a PulseBlock
@@ -200,12 +210,17 @@ class PulseBlock(object):
         return result
 
     def __eq__(self, other):
-        # ignore label in equality testing
-        mydict = self.__dict__.copy()
-        otherdict = other.__dict__.copy()
-        mydict.pop('label')
-        otherdict.pop('label')
-        return mydict == otherdict
+        if isinstance(other, self.__class__):
+            # ignore label in equality testing
+            mydict = self.__dict__.copy()
+            otherdict = other.__dict__.copy()
+            mydict.pop('label')
+            otherdict.pop('label')
+            return mydict == otherdict
+        return False
+
+    def __ne__(self, other):
+        return not self == other
 
     #PulseBlocks don't need to be promoted, so just return self
     def promote(self):

--- a/QGL/PulseSequencer.py
+++ b/QGL/PulseSequencer.py
@@ -91,13 +91,13 @@ class Pulse(object):
         params['samplingRate'] = self.qubit.physChan.samplingRate
         return self.shapeFun(**params)
 
-def TAPulse(label, qubits, length, amp, phase, frameChange):
+def TAPulse(label, qubits, length, amp, phase=0, frameChange=0):
     '''
     Creates a time/amplitude pulse with the given pulse length and amplitude
     '''
-    p = Pulse(label, qubits, np.array([amp], np.complex), phase, frameChange)
+    params = {'amp': amp, 'length': length}
+    p = Pulse(label, qubits, PulseShapes.constant, params, phase, frameChange)
     p.isTimeAmp = True
-    p.TALength = int(round(length))
     return p
 
 class CompositePulse(object):

--- a/QGL/PulseShapes.py
+++ b/QGL/PulseShapes.py
@@ -3,6 +3,7 @@ All generic pulse shapes are defined here.
 '''
 
 import numpy as np
+from math import pi, sin, cos, acos, sqrt
 
 def gaussian(amp=1, length=0, cutoff=2, samplingRate=1e9, **params):
     '''
@@ -132,4 +133,48 @@ def autodyne(frequency=10e6, baseShape=constant, **params):
     # Apply the autodyne frequency
     timePts = np.linspace(0, params['length'], len(shape))
     shape *= np.exp(-1j*2*np.pi*frequency*timePts)
+    return shape
+
+def arb_axis_drag(nutFreq, rotAngle=0, polarAngle=0, aziAngle=0, length=0, dragScaling=0.5, samplingRate=1e9, **params):
+    """
+    Single-qubit arbitrary axis pulse implemented with phase ramping and frame change.
+    For now we assume gaussian shape.
+
+    Parameters
+    ----------
+    nutFreq: effective nutation frequency per unit of drive amplitude (Hz)
+    rotAngle : effective rotation rotAngle (radians)
+    polarAngle : polar angle of rotation axis (radians)
+    aziAngle : azimuthal (radians)
+    """
+
+    if length > 0:
+        #Start from a gaussian shaped pulse
+        gaussPulse = gaussian(amp=1, length=length, samplingRate=samplingRate, **params)
+
+        #Scale to achieve to the desired rotation
+        calScale = (rotAngle/2/pi)*samplingRate/sum(gaussPulse)
+
+        #Calculate the phase ramp steps to achieve the desired Z component to the rotation axis
+        phaseSteps = -2*pi*cos(polarAngle)*calScale*gaussPulse/samplingRate
+
+        #Calculate Z DRAG correction to phase steps
+        #beta is a conversion between XY drag scaling and Z drag scaling
+        beta = dragScaling/samplingRate
+        instantaneousDetuning = beta*(2*pi*calScale*sin(polarAngle)*gaussPulse)**2
+        phaseSteps = phaseSteps + instantaneousDetuning*(1.0/samplingRate)
+        #center phase ramp around the middle of the pulse time steps
+        phaseRamp = np.cumsum(phaseSteps) - phaseSteps/2
+
+        frameChange = sum(phaseSteps);
+
+        shape = (1.0/nutFreq)*sin(polarAngle)*calScale*gaussPulse*np.exp(1j*phaseRamp)
+
+    elif abs(polarAngle) < 1e-10:
+        #Otherwise assume we have a zero-length Z rotation
+        frameChange = -rotAngle;
+        shape = np.array([], dtype=np.complex128)
+    else:
+        raise ValueError('Non-zero transverse rotation with zero-length pulse.')
+
     return shape

--- a/QGL/PulseShapes.py
+++ b/QGL/PulseShapes.py
@@ -27,11 +27,14 @@ def delay(length=0, samplingRate=1e9, **params):
     '''
     A delay between pulses.
     '''
-    #Return a single point at 0
-    # return np.zeros(1, dtype=np.complex)
-    numPts = np.round(length*samplingRate)
-    return np.zeros(numPts, dtype=np.complex)
+    return constant(amp=0, length, samplingRate)
 
+def constant(amp=1, length=0, samplingRate=1e9, **params):
+    '''
+    A constant section.
+    '''
+    numPts = np.round(length*samplingRate)
+    return amp*np.ones(numPts, dtype=np.complex)
 
 def drag(amp=1, length=0, cutoff=2, dragScaling=0.5, samplingRate=1e9, **params):
     '''

--- a/QGL/PulseShapes.py
+++ b/QGL/PulseShapes.py
@@ -27,7 +27,7 @@ def delay(length=0, samplingRate=1e9, **params):
     '''
     A delay between pulses.
     '''
-    return constant(amp=0, length, samplingRate)
+    return constant(0, length, samplingRate)
 
 def constant(amp=1, length=0, samplingRate=1e9, **params):
     '''
@@ -123,3 +123,13 @@ def measPulse(amp=1, length=0, sigma=0, samplingRate=1e9, **params):
     numPts = np.round(length*samplingRate)
     timePts = (1.0/samplingRate)*np.arange(numPts)
     return amp*(0.8*np.exp(-timePts/sigma) + 0.2).astype(np.complex)
+
+def autodyne(frequency=10e6, baseShape=constant, **params):
+    '''
+    A pulse with modulation at a particular frequency baked in.
+    '''
+    shape = baseShape(**params)
+    # Apply the autodyne frequency
+    timePts = np.linspace(0, params['length'], len(shape))
+    shape *= np.exp(-1j*2*np.pi*frequency*timePts)
+    return shape

--- a/QGL/__init__.py
+++ b/QGL/__init__.py
@@ -1,9 +1,9 @@
 from Channels import QubitFactory, MeasFactory, Qubit
 from PulsePrimitives import *
 from Compiler import compile_to_hardware
-from PulseSequencer import show, align, build_waveforms, plot_waveforms
+from PulseSequencer import align, build_waveforms, plot_waveforms
 from ControlFlow import repeat, repeatall, qif, qwhile, qdowhile, qfunction, qwait, qsync
 from BasicSequences import *
-from Plotting import output_file, output_notebook
+from Plotting import output_file, output_notebook, show
 from PulseSequencePlotter import plot_pulse_files
 from Tomography import state_tomo, process_tomo

--- a/QGL/__init__.py
+++ b/QGL/__init__.py
@@ -1,9 +1,9 @@
 from Channels import QubitFactory, MeasFactory, Qubit
 from PulsePrimitives import *
 from Compiler import compile_to_hardware
-from PulseSequencer import align, build_waveforms, plot_waveforms
+from PulseSequencer import align
 from ControlFlow import repeat, repeatall, qif, qwhile, qdowhile, qfunction, qwait, qsync
 from BasicSequences import *
-from Plotting import output_file, output_notebook, show
+from Plotting import output_file, output_notebook, show, build_waveforms, plot_waveforms
 from PulseSequencePlotter import plot_pulse_files
 from Tomography import state_tomo, process_tomo

--- a/tests/test_APSPattern.py
+++ b/tests/test_APSPattern.py
@@ -38,10 +38,22 @@ class APSPatternUtils(unittest.TestCase):
         seqs = [repeat(2, [X(q1),Y(q1)] + repeat(3, [Z(q1)]) + [Y(q1),X(q1)]), [X(q1), Y(q1)]]
         a, b = APSPattern.unroll_loops(seqs)
 
-        seqUnrolled = ([X(q1),Y(q1)] + [Z(q1)]*3 + [Y(q1),X(q1)])*2
+        loopedZ = Z(q1)
+        loopedZ.repeat = 3
+        seqUnrolled = ([X(q1),Y(q1), loopedZ, Y(q1),X(q1)])*2
 
         assert(a[0] == seqUnrolled)
 
+        assert(b == 0)
+
+    def test_unroll_single_entry(self):
+        q1 = self.q1
+        seqs = [repeat(5, [X(q1)]) + [Y(q1)]]
+        a, b = APSPattern.unroll_loops(seqs)
+        seqUnrolled = [X(q1), Y(q1)]
+        seqUnrolled[0].repeat = 5
+
+        assert(a[0] == seqUnrolled)
         assert(b == 0)
 
 if __name__ == "__main__":    

--- a/tests/test_APSPattern.py
+++ b/tests/test_APSPattern.py
@@ -3,7 +3,6 @@ import unittest
 import numpy as np
 
 from QGL import *
-from QGL.BlockLabel import label
 
 class APSPatternUtils(unittest.TestCase):
     def setUp(self):
@@ -39,7 +38,7 @@ class APSPatternUtils(unittest.TestCase):
         seqs = [repeat(2, [X(q1),Y(q1)] + repeat(3, [Z(q1)]) + [Y(q1),X(q1)]), [X(q1), Y(q1)]]
         a, b = APSPattern.unroll_loops(seqs)
 
-        seqUnrolled = ([X(q1).promote(),Y(q1)] + [Z(q1).promote()]*3 + [Y(q1),X(q1)])*2
+        seqUnrolled = ([X(q1),Y(q1)] + [Z(q1)]*3 + [Y(q1),X(q1)])*2
 
         assert(a[0] == seqUnrolled)
 

--- a/tests/test_ControlFlow.py
+++ b/tests/test_ControlFlow.py
@@ -40,10 +40,9 @@ class ControlFlowTest(unittest.TestCase):
     def test_qwhile(self):
         q1 = self.q1
         seq1 = [X90(q1), Y90(q1)]
-        label(seq1)
-        # print qwhile(0, seq1)
-        # print [CmpNeq(0), Goto(endlabel(seq1))] + seq1
-        assert( qwhile(0, seq1) == [CmpNeq(0), Goto(endlabel(seq1))] + seq1 )
+        seq2 = qwhile(0, seq1)
+        seq3 = [label(seq2), CmpNeq(0), Goto(endlabel(seq2))] + seq1 + [Goto(label(seq2)), endlabel(seq2)]
+        assert( seq2 ==  seq3)
 
     def test_qdowhile(self):
         q1 = self.q1

--- a/tests/test_ControlFlow.py
+++ b/tests/test_ControlFlow.py
@@ -28,7 +28,6 @@ class ControlFlowTest(unittest.TestCase):
         # if and else branches
         seq = qif(0, X(q1), Y(q1))
 
-    @unittest.expectedFailure
     def test_inline_qif(self):
         q1 = self.q1
         seq = [X90(q1), Y(q1), qwait("CMP"), qif(0, [Id(q1)], [X(q1)]), Y(q1)]
@@ -80,12 +79,6 @@ class ControlFlowTest(unittest.TestCase):
         seq1 = [qwait(), qwait("CMP")]
         assert( isinstance(seq1[0], ControlFlow.Wait) )
         assert( isinstance(seq1[1], ControlFlow.LoadCmp) )
-
-    def test_flatten_and_separate(self):
-        seq = [1, ([2, ([3], [4, ([5, 6, 7], [8, 9])])], [10, 11])]
-        main, branch = Compiler.flatten_and_separate(seq)
-        assert( main == [1,2,3] )
-        assert( branch == [4,5,6,7,8,9,10,11] )
 
     def test_compile(self):
         q1 = self.q1

--- a/tests/test_ControlFlow.py
+++ b/tests/test_ControlFlow.py
@@ -85,11 +85,14 @@ class ControlFlowTest(unittest.TestCase):
         seq2 = [X(q1), Y(q1), Z(q1)]
         label(seq1)
         label(seq2)
-        mainLL, wfs1 = Compiler.compile_sequence(seq1 + seq2)
-        mainLL, wfs2 = Compiler.compile_sequence([X(q1), qif(0, seq1), Y(q1)])
-        assert(wfs1 == wfs2)
-        mainLL, wfs3 = Compiler.compile_sequence([X(q1), qif(0, seq1, seq2), Y(q1)])
-        assert(wfs1 == wfs3)
+        # mainLL, wfs1 = Compiler.compile_sequence(seq1 + seq2)
+        seqIR = Compiler.compile_sequence(seq1 + seq2)
+        # mainLL, wfs2 = Compiler.compile_sequence([X(q1), qif(0, seq1), Y(q1)])
+        seqIR = Compiler.compile_sequence([X(q1), qif(0, seq1), Y(q1)])
+        # assert(wfs1 == wfs2)
+        # mainLL, wfs3 = Compiler.compile_sequence([X(q1), qif(0, seq1, seq2), Y(q1)])
+        seqIR = Compiler.compile_sequence([X(q1), qif(0, seq1, seq2), Y(q1)])
+        # assert(wfs1 == wfs3)
 
 
 if __name__ == "__main__":

--- a/tests/test_ControlFlow.py
+++ b/tests/test_ControlFlow.py
@@ -62,9 +62,8 @@ class ControlFlowTest(unittest.TestCase):
         crseq = Reset(q1)
         seq1 = [Call(label(crseq[1]))]
         # print seq1
-        subseq2 = crseq[1][2:-1]
-        seq2 = [CmpNeq(1), Goto(endlabel(subseq2))] + subseq2 + [Return()]
-        seq2[0].label = crseq[1][0].label
+        subseq2 = crseq[1][3:-1]
+        seq2 = [label(crseq[1]), CmpNeq(1), Goto(endlabel(subseq2))] + subseq2 + [Return()]
         # print seq2
         assert( Reset(q1) == (seq1, seq2) )
 

--- a/tests/test_ControlFlow.py
+++ b/tests/test_ControlFlow.py
@@ -55,17 +55,18 @@ class ControlFlowTest(unittest.TestCase):
 
     def test_qcall(self):
         q1 = self.q1
+        q2 = self.q2
         @qfunction
-        def Reset(q):
-            return qwhile(1, [X(q)])
+        def dummy(q):
+            return [X(q), Y(q)]
 
-        crseq = Reset(q1)
-        seq1 = [Call(label(crseq[1]))]
-        # print seq1
-        subseq2 = crseq[1][3:-1]
-        seq2 = [label(crseq[1]), CmpNeq(1), Goto(endlabel(subseq2))] + subseq2 + [Return()]
-        # print seq2
-        assert( Reset(q1) == (seq1, seq2) )
+        # multiple calls should return the same thing
+        assert dummy(q1) == dummy(q1)
+        assert dummy(q2) == dummy(q2)
+        assert dummy(q1) != dummy(q2)
+
+        # specialization lookup with label at beginning and RETURN at end
+        assert ControlFlow.qfunction_specialization(dummy(q1).target) == [dummy(q1).target, X(q1), Y(q1), Return()]
 
     def test_repeat(self):
         q1 = self.q1

--- a/tests/test_Sequences.py
+++ b/tests/test_Sequences.py
@@ -141,8 +141,10 @@ class AWGTestHelper(object):
 		if not test:
 			bad_idx = np.where(diff == False)[0]
 			percent_bad = float(len(bad_idx))/len(seqA)
+			bad_level = np.mean(np.abs(seqA - seqB)[bad_idx]) / self.tolerance
 			if percent_bad < 0.6:
 				msg = "{0}.\nFailed indices: ({1:.1f}% mismatch)\n{2}".format(errorHeader, 100*percent_bad, bad_idx)
+				msg += "\nAvg failure level: {0}".format(bad_level)
 			else:
 				msg = "{0} ({1:.1f}% mismatch)".format(errorHeader, 100*percent_bad)
 		else:
@@ -209,18 +211,18 @@ class TestSequences(object):
 
 	def test_CR_PiRabi(self):
 		self.set_awg_dir()
-	  	PiRabi(self.q1, self.q2, self.cr,  np.linspace(0, 5e-6, 11))
-	  	self.compare_sequences('PiRabi')
+		PiRabi(self.q1, self.q2, self.cr,  np.linspace(0, 4e-6, 11))
+		self.compare_sequences('PiRabi')
 
 	def test_CR_EchoCRLen(self):
 		self.set_awg_dir('EchoCRLen')
-	  	EchoCRLen(self.q1, self.q2, self.cr,  np.linspace(0, 5e-6, 11))
-	  	self.compare_sequences('EchoCR')
+		EchoCRLen(self.q1, self.q2, self.cr,  np.linspace(0, 2e-6, 11))
+		self.compare_sequences('EchoCR')
 
 	def test_CR_EchoCRPhase(self):
 		self.set_awg_dir('EchoCRPhase')
-	  	EchoCRPhase(self.q1, self.q2, self.cr,  np.linspace(0, pi/2, 11))
-	  	self.compare_sequences('EchoCR')
+		EchoCRPhase(self.q1, self.q2, self.cr,  np.linspace(0, pi/2, 11))
+		self.compare_sequences('EchoCR')
 
 	def test_Decoupling_HannEcho(self):
 		self.set_awg_dir()

--- a/tests/test_Sequences.py
+++ b/tests/test_Sequences.py
@@ -147,9 +147,9 @@ class AWGTestHelper(object):
 			bad_idx = np.where(diff == False)[0]
 			percent_bad = float(len(bad_idx))/len(seqA)
 			if percent_bad < 0.8:
-				msg = "{0}.\nFailed indices: ({1:.2f}% incorrect)\n{2}".format(errorHeader, percent_bad, bad_idx)
+				msg = "{0}.\nFailed indices: ({1:.1f}% incorrect)\n{2}".format(errorHeader, 100*percent_bad, bad_idx)
 			else:
-				msg = "{0} ({1:.2f% incorrect)".format(errorHeader, percent_bad)
+				msg = "{0} ({1:.1f}% incorrect)".format(errorHeader, percent_bad)
 		else:
 			msg = ""
 		self.assertTrue(npdiff or all(diff), msg)

--- a/tests/test_Sequences.py
+++ b/tests/test_Sequences.py
@@ -183,13 +183,15 @@ class TestSequences(object):
 		filenames = compile_to_hardware(seqs, 'MISC4/MISC4')
 		self.compare_sequences('MISC4')
 
-	def test_misc_seqs5(self):
-		""" catch all for sequences not otherwise covered """
-		self.set_awg_dir()
-		seqs = [[MEASmux((self.q1, self.q2))]]
+	# TODO: replace with a [MEAS(q1)*MEAS(q2)] sequence where M-q1 and M-q2 share
+	# a physical channel.
+	# def test_misc_seqs5(self):
+	# 	""" catch all for sequences not otherwise covered """
+	# 	self.set_awg_dir()
+	# 	seqs = [[MEASmux((self.q1, self.q2))]]
 
-		filenames = compile_to_hardware(seqs, 'MISC5/MISC5')
-		self.compare_sequences('MISC5')
+	# 	filenames = compile_to_hardware(seqs, 'MISC5/MISC5')
+	# 	self.compare_sequences('MISC5')
 
 	def test_AllXY(self):
 		self.set_awg_dir()

--- a/tests/test_Sequences.py
+++ b/tests/test_Sequences.py
@@ -402,15 +402,6 @@ class TestAPS1(unittest.TestCase, AWGTestHelper, TestSequences):
 		"""
 		TestSequences.test_Rabi_RabiWidth(self)
 
-	@unittest.expectedFailure
-	def test_misc_seqs4(self):
-		""" Fails due to a list index out of range
-		  File "C:\Projects\Q\lib\PyQLab\QGL\APSPattern.py", line 344, in merge_APS_markerDat
-    		while (isinstance(miniLL_IQ[curIQIdx], ControlFlow.ControlInstruction) or
-		  IndexError: list index out of range
-		"""
-		TestSequences.test_misc_seqs4(self)
-
 class TestTek5014(unittest.TestCase, AWGTestHelper, TestSequences):
 
 	def setUp(self):

--- a/tests/test_Sequences.py
+++ b/tests/test_Sequences.py
@@ -127,15 +127,10 @@ class AWGTestHelper(object):
 		for name in truthData:
 			self.assertTrue(name in awgData, "Expected channel {0} not found in file {1}".format(name, testFile))
 
-			if len(truthData[name][0]) == 1:
-				seqA = np.array(truthData[name])
-				seqB = np.array(awgData[name])
-				self.compare_sequence(seqA,seqB, "\nFile {0} =>\nChannel {1}".format(testFile, name))
-			else:
-				for x in range(len(truthData[name])):
-					seqA = np.array(truthData[name][x])
-					seqB = np.array(awgData[name][x])
-					self.compare_sequence(seqA,seqB,  "\nFile {0} =>\nChannel {1} Sequence {2}".format(testFile, name, x))
+			for x in range(len(truthData[name])):
+				seqA = np.array(truthData[name][x])
+				seqB = np.array(awgData[name][x])
+				self.compare_sequence(seqA,seqB,  "\nFile {0} =>\nChannel {1} Sequence {2}".format(testFile, name, x))
 
 	def compare_sequence(self, seqA, seqB, errorHeader):
 		self.assertTrue( seqA.size == seqB.size, "{0} size {1} != size {2}".format(errorHeader, str(seqA.size), str(seqB.size)))
@@ -146,10 +141,10 @@ class AWGTestHelper(object):
 		if not test:
 			bad_idx = np.where(diff == False)[0]
 			percent_bad = float(len(bad_idx))/len(seqA)
-			if percent_bad < 0.8:
-				msg = "{0}.\nFailed indices: ({1:.1f}% incorrect)\n{2}".format(errorHeader, 100*percent_bad, bad_idx)
+			if percent_bad < 0.6:
+				msg = "{0}.\nFailed indices: ({1:.1f}% mismatch)\n{2}".format(errorHeader, 100*percent_bad, bad_idx)
 			else:
-				msg = "{0} ({1:.1f}% incorrect)".format(errorHeader, percent_bad)
+				msg = "{0} ({1:.1f}% mismatch)".format(errorHeader, 100*percent_bad)
 		else:
 			msg = ""
 		self.assertTrue(npdiff or all(diff), msg)


### PR DESCRIPTION
This is a significant re-write of some of the QGL internals. Basically the goal is to delay creating concrete pulse shapes until we pass the QGL IR off to the various hardware translators. This will allow for greater flexibility in determining which parameters are encoded at compile-time vs run-time (e.g. SSB modulation).

This PR includes updated APS1 and APS2 translators. The Tek5014 translator is still TODO. Since this PR targets current develop prior to Brian's new code coverage improvements, I have some concerns about how well this code will perform in practice. So, it's needs some real-world testing before I am comfortable in merging it.