### PR TITLE
Added a configurable background fill option for plotting

### DIFF
--- a/QGL/Plotting.py
+++ b/QGL/Plotting.py
@@ -24,6 +24,8 @@ import os.path, uuid, tempfile
 import bokeh.plotting as bk
 import numpy as np
 
+import config
+
 #Effective global of whether we are interactive plottinn in a notebook or to a
 #static html file
 _in_ipynb = False
@@ -72,6 +74,7 @@ def plot_waveforms(waveforms, figTitle = ''):
     plots = []
     for (ct,chan) in enumerate(channels):
         fig = bk.figure(title=figTitle + repr(chan), plot_width=800, plot_height=350, y_range=[-1.05, 1.05])
+        fig.background_fill = config.plotBackground
         waveformToPlot = waveforms[chan]
         xpts = np.linspace(0,len(waveformToPlot)/chan.physChan.samplingRate/1e-6,len(waveformToPlot))
         fig.line(xpts, np.real(waveformToPlot), color='red')

--- a/QGL/PulseSequencePlotter.py
+++ b/QGL/PulseSequencePlotter.py
@@ -43,6 +43,8 @@ import uuid, tempfile
 
 import Libraries
 
+import config
+
 # define sequence reader dispatch on awg type
 @multimethod(Tek5014, unicode)
 def read_sequence_file(awg, filename):
@@ -102,6 +104,7 @@ def plot_pulse_files(fileNames, firstSeqNum=0):
 
     source = bk.ColumnDataSource(data=dataDict)
     figH = bk.figure(title=title, plot_width=1000, y_range=(-1,len(dataDict)+1))
+    figH.background_fill = config.plotBackground
 
     #Colorbrewer2 qualitative Set3 (http://colorbrewer2.org)
     colours = ["#8dd3c7", "#ffffb3", "#bebada", "#fb8072", "#80b1d3", "#fdb462",

--- a/config.py
+++ b/config.py
@@ -31,4 +31,4 @@ measurementLibFile = PyQLabCfg['MeasurementLibraryFile']
 quickpickFile = PyQLabCfg['QuickPickFile'] if 'QuickPickFile' in PyQLabCfg else ''
 
 # plotting options
-plotBackground = PyQLabCfg['PlotBackground'] if 'PlotBackground' in PyQLabCfg else 'white'
+plotBackground = PyQLabCfg['PlotBackground'] if 'PlotBackground' in PyQLabCfg else 'lightgray'

--- a/config.py
+++ b/config.py
@@ -29,3 +29,6 @@ instrumentLibFile = PyQLabCfg['InstrumentLibraryFile']
 sweepLibFile = PyQLabCfg['SweepLibraryFile']
 measurementLibFile = PyQLabCfg['MeasurementLibraryFile']
 quickpickFile = PyQLabCfg['QuickPickFile'] if 'QuickPickFile' in PyQLabCfg else ''
+
+# plotting options
+plotBackground = PyQLabCfg['PlotBackground'] if 'PlotBackground' in PyQLabCfg else 'white'

--- a/startup.py
+++ b/startup.py
@@ -3,6 +3,7 @@ from Libraries import instrumentLib, channelLib
 import numpy as np
 from QGL import *
 import QGL
+import config as PQconfig
 
 QGL.Compiler.channelLib = channelLib
 QGL.Compiler.instrumentLib = instrumentLib


### PR DESCRIPTION
Adds a new field to config called plotBackground which defaults to 'white' or may be overridden in config.json. 

The field is used to set the background fill for the bokeh plots. 

Added an import statement to startup.py so the config would be exposed as PQconfig in the jupyter notebooks. This lets the user change the background as they are making their plots. For example

PQconfig.plotBackground = "#000000" 

or

PQconfig.plotBackground = "gray" 
