### PR TITLE
fix for #69,#71, and #72

### DIFF
--- a/DictManager.py
+++ b/DictManager.py
@@ -39,8 +39,8 @@ class DictManager(Atom):
             self.itemDict.pop(itemLabel)
             #TODO: once ContainerDicts land see if we still need this
             self.displayList.pop(self.displayList.index(itemLabel))
-        else:
-            print("WARNING: %s is not in the list"%itemLabel)
+        elif itemLabel != '':
+            self.displayList.pop(self.displayList.index(itemLabel))
 
     def name_changed(self, oldLabel, newLabel):
         # Add copy of changing item

--- a/ExpSettingsView.enaml
+++ b/ExpSettingsView.enaml
@@ -1,5 +1,5 @@
 from enaml.widgets.api import MainWindow, Window, Container, Notebook, Page, MenuBar, \
-					 Menu, Action, FileDialog, ComboBox, PushButton, PopupView, Label, \
+					 Menu, Action, FileDialogEx, ComboBox, PushButton, PopupView, Label, \
 					 CheckBox, Form
 from enaml.core.api import Looper
 from enaml.layout.api import hbox, vbox, spacer, align
@@ -8,6 +8,7 @@ from QGL.ChannelsViews import ChannelLibraryView
 from instruments.InstrumentManagerView import InstrumentManagerView
 from SweepsViews import SweepManager
 from MeasFiltersViews import MeasFilterManager
+import os, sys, time
 
 
 #See what's in the quick pick file to enumerate it
@@ -24,6 +25,7 @@ def get_update_script_file_callback(expSettings):
 	def update_script_file_callback(dlg):
 		if dlg.result == 'accepted': #if the pressed "open" otherwise we get 'rejected'
 			expSettings.curFileName = dlg.path
+			print(expSettings.curFileName)
 	return update_script_file_callback
 
 chosenQuickPick = bytearray("")
@@ -92,12 +94,42 @@ enamldef ExpSettingsView(MainWindow): main:
 						ep.center_on_widget(main)
 						
 			Action:
-				text = 'Save As\tCtrl+Shift+S'
+				text = 'Save Config As\tCtrl+Shift+S'
 				tool_tip = 'Save to a new setting file'
 				triggered ::
-					dlg = FileDialog(root_object(), title='Choose a script file..', mode='save_file',
-						callback=get_update_script_file_callback(expSettings), filters=['*.json'])
-					dlg.open()
+					path = FileDialogEx.get_existing_directory(main,show_dirs_only=False)
+					if not os.path.isdir(path) and path !='':
+						print('% s Does not Exist: Creating %s'%(path,path))
+						os.mkdir(path)
+					
+						if expSettings.save_config(path):
+							NotificationPopup(main, window_type='window', displayText="Config Saved").show()
+						else:
+							ep = ErrorPopup(displayText=expSettings.format_errors())
+							ep.show()
+							ep.center_on_widget(main)
+			
+			Action:
+				text = 'Load Config\tCtrl+Shift+O'
+				tool_tip = 'Load Config Files from Saved Location'
+				triggered ::
+					path = FileDialogEx.get_existing_directory(main,show_dirs_only=False)
+					if not os.path.isdir(path):
+						print('% s Does not Exist: Creating %s'%(path,path))
+						ep = ErrorPopup(displayText=expSettings.format_errors())
+						ep.show()
+						ep.center_on_widget(main)
+						os.mkdir(path)
+					
+					if expSettings.load_config(path):
+						NotificationPopup(main, window_type='window', displayText="New Config Loaded ... Restarting GUI").show()
+						os.execl(sys.executable, sys.executable, * sys.argv)
+						
+					else:
+						ep = ErrorPopup(displayText=expSettings.format_errors())
+						ep.show()
+						ep.center_on_widget(main)
+						
 			Action:
 				text = "Stash current settings"
 				enabled = False

--- a/MeasFilters.py
+++ b/MeasFilters.py
@@ -120,11 +120,14 @@ class MeasFilterLibrary(Atom):
     def __getitem__(self, filterName):
         return self.filterDict[filterName]
 
-    def write_to_file(self):
+    def write_to_file(self,fileName=None):
         #Move import here to avoid circular import
         import JSONHelpers
-        if self.libFile:
-            with open(self.libFile,'w') as FID:
+        
+        libFileName = fileName if fileName != None else self.libFile
+        
+        if libFileName:
+            with open(libFileName, 'w') as FID:
                 json.dump(self, FID, cls=JSONHelpers.LibraryEncoder, indent=2, sort_keys=True)
 
     def load_from_library(self):
@@ -162,12 +165,13 @@ measFilterList = [RawStream, DigitalDemod, KernelIntegration, Correlator, StateC
 if __name__ == "__main__":
 
     #Work around annoying problem with multiple class definitions
-    from MeasFilters import DigitalHomodyne, Correlator, MeasFilterLibrary
+    from MeasFilters import DigitalDemod, Correlator, MeasFilterLibrary
 
-    testFilter1 = DigitalHomodyne(label='M1', boxCarStart=100, boxCarStop=500, IFfreq=10e6, samplingRate=250e6, channel=1)
-    testFilter2 = DigitalHomodyne(label='M2', boxCarStart=150, boxCarStop=600, IFfreq=39.2e6, samplingRate=250e6, channel=2)
-    testFilter3 = Correlator(label='M12')
-    filterDict = {'M1':testFilter1, 'M2':testFilter2, 'M12':testFilter3}
+    testFilter1 = DigitalDemod(label='M1')
+    testFilter2 = DigitalDemod(label='M2')
+    testFilter3 = Correlator(label='M3')
+    testFilter4 = Correlator(label='M4')
+    filterDict = {'M1':testFilter1, 'M2':testFilter2, 'M3':testFilter3,'M4':testFilter4}
 
     testLib = MeasFilterLibrary(libFile='MeasFilterLibrary.json', filterDict=filterDict)
 

--- a/MeasFiltersViews.enaml
+++ b/MeasFiltersViews.enaml
@@ -177,6 +177,16 @@ enamldef KernelIntegrationForm(GroupBox):
             obj := myFilter
             enumName = 'plotMode'
 
+#moved this logic to a separate function to tidy things up a bit
+def filterLooperGetIdndex(filterLib,myFilter,loop_index):
+    if loop_index < len(myFilter.filters)  and \
+        myFilter.filters[loop_index] in filterLib.filterDict.values():
+        return filterLib.filterDict.values().index(myFilter.filters[loop_index])
+    else:
+        return -1
+    
+    
+
 enamldef CorrelatorView(GroupBox):
     attr myFilter
     attr filterLib
@@ -199,7 +209,7 @@ enamldef CorrelatorView(GroupBox):
                     text = 'Filter {}:'.format(loop_index+1)
                 ComboBox:
                     items << filterLib.filterDict.keys()
-                    index << filterLib.filterDict.values().index(myFilter.filters[loop_index]) if loop_index < len(myFilter.filters) and myFilter.filters[loop_index] else -1
+                    index << filterLooperGetIdndex(filterLib,myFilter,loop_index)
                     index ::
                         myFilter.filters[loop_index] = filterLib.filterDict[selected_item]
         Label:

--- a/QGL/Channels.py
+++ b/QGL/Channels.py
@@ -287,13 +287,14 @@ class ChannelLibrary(Atom):
                 self.connectivityG.add_edge(chan.source, chan.target)
                 self.connectivityG[chan.source][chan.target]['channel'] = chan
 
-    def write_to_file(self):
+    def write_to_file(self,fileName=None):
         import JSONHelpers
-        if self.libFile:
+        libFileName = fileName if fileName != None else self.libFile
+        if libFileName:
             #Pause the file watcher to stop cicular updating insanity
             if self.fileWatcher:
                 self.fileWatcher.pause()
-            with open(self.libFile, 'w') as FID:
+            with open(libFileName, 'w') as FID:
                 json.dump(self, FID, cls=JSONHelpers.LibraryEncoder, indent=2, sort_keys=True)
             if self.fileWatcher:
                 self.fileWatcher.resume()

--- a/Sweeps.py
+++ b/Sweeps.py
@@ -147,10 +147,13 @@ class SweepLibrary(Atom):
     def _get_sweepList(self):
         return [sweep.label for sweep in self.sweepDict.values() if sweep.enabled]
 
-    def write_to_file(self):
+    def write_to_file(self,fileName=None):
         import JSONHelpers
-        if self.libFile:
-            with open(self.libFile, 'w') as FID:
+        
+        libFileName = fileName if fileName != None else self.libFile
+        
+        if libFileName:
+            with open(libFileName, 'w') as FID:
                 json.dump(self, FID, cls=JSONHelpers.LibraryEncoder, indent=2, sort_keys=True)
 
     def load_from_library(self):

--- a/config.py
+++ b/config.py
@@ -23,12 +23,13 @@ with open(PyQLabCfgFile, 'r') as f:
 	PyQLabCfg = json.load(f)
 
 #pull out the variables 
-AWGDir = PyQLabCfg['AWGDir']
-channelLibFile = PyQLabCfg['ChannelLibraryFile']
-instrumentLibFile = PyQLabCfg['InstrumentLibraryFile']
-sweepLibFile = PyQLabCfg['SweepLibraryFile']
-measurementLibFile = PyQLabCfg['MeasurementLibraryFile']
-quickpickFile = PyQLabCfg['QuickPickFile'] if 'QuickPickFile' in PyQLabCfg else ''
+#abspath allows the use of relative file names in the config file
+AWGDir = os.path.abspath(PyQLabCfg['AWGDir'])
+channelLibFile = os.path.abspath(PyQLabCfg['ChannelLibraryFile'])
+instrumentLibFile = os.path.abspath(PyQLabCfg['InstrumentLibraryFile'])
+sweepLibFile = os.path.abspath(PyQLabCfg['SweepLibraryFile'])
+measurementLibFile = os.path.abspath(PyQLabCfg['MeasurementLibraryFile'])
+quickpickFile = os.path.abspath(PyQLabCfg['QuickPickFile']) if 'QuickPickFile' in PyQLabCfg else ''
 
 # plotting options
 plotBackground = PyQLabCfg['PlotBackground'] if 'PlotBackground' in PyQLabCfg else '#EAEAF2'

--- a/instruments/AWGs.py
+++ b/instruments/AWGs.py
@@ -10,26 +10,15 @@ from Instrument import Instrument
 import enaml
 from enaml.qt.qt_application import QtApplication
 
-from AWGBase import AWGChannel, AWG, AWGDriver
+from instruments.AWGBase import AWGChannel, AWG, AWGDriver
 
 from glob import glob
 from importlib import import_module
 import os
 import inspect
 
+
 AWGList = []
-
-if __name__ == "__main__":
-
-
-    with enaml.imports():
-        from AWGsViews import AWGView
-
-    awg = APS(label='BBNAPS1')
-    app = QtApplication()
-    view = AWGView(awg=awg)
-    view.show()
-    app.start()
 
 def find_drivers():
     dirPath = os.path.dirname(__file__)
@@ -47,3 +36,16 @@ def find_drivers():
                 print 'Registered Driver {0}'.format(name)
 
 find_drivers()
+
+if __name__ == "__main__":
+
+
+    with enaml.imports():
+        from AWGsViews import AWGView
+
+    awg = APS(label='BBNAPS1')
+    app = QtApplication()
+    view = AWGView(awg=awg)
+    view.show()
+    app.start()
+

--- a/instruments/InstrumentManager.py
+++ b/instruments/InstrumentManager.py
@@ -55,15 +55,19 @@ class InstrumentLibrary(Atom):
     def __getitem__(self, instrName):
         return self.instrDict[instrName]
 
-    def write_to_file(self):
+    def write_to_file(self,fileName=None):
         #Move import here to avoid circular import
         import JSONHelpers
+        libFileName = fileName if fileName != None else self.libFile
         if self.libFile:
             #Pause the file watcher to stop circular updating insanity
             if self.fileWatcher:
                 self.fileWatcher.pause()
-            with open(self.libFile,'w') as FID:
-                json.dump(self, FID, cls=JSONHelpers.LibraryEncoder, indent=2, sort_keys=True)
+                
+                if libFileName:
+                    with open(libFileName, 'w') as FID:
+                        json.dump(self, FID, cls=JSONHelpers.LibraryEncoder, indent=2, sort_keys=True)
+            
             if self.fileWatcher:
                 self.fileWatcher.resume()
 

--- a/widgets/qt_list_str_widget.py
+++ b/widgets/qt_list_str_widget.py
@@ -99,15 +99,19 @@ class QtListStrWidget(RawWidget):
         itemRow = widget.indexFromItem(item).row()
         oldLabel = self.items[itemRow]
         newLabel = item.text()
-        if oldLabel != newLabel:
+        
+        #only signal the enable change when the labels are the same and is in
+        #the item list, also only signal a name change when the labels are not
+        #the same and the newlabel is not in the item list
+        if newLabel == oldLabel and newLabel in self.items:
+            self.checked_states[itemRow] = True if item.checkState() == Qt.Checked else False
+            self.enable_changed(item.text(), self.checked_states[itemRow])
+        elif oldLabel != newLabel and newLabel not in self.items:
             self.item_changed(oldLabel, newLabel)
             self.selected_item = item.text()
             self.items[itemRow] = item.text()
             self.apply_validator(item, newLabel)
-        else:
-            self.checked_states[itemRow] = True if item.checkState() == Qt.Checked else False
-            self.enable_changed(item.text(), self.checked_states[itemRow])
-
+        
     #--------------------------------------------------------------------------
     # ProxyListStrView API
     #--------------------------------------------------------------------------


### PR DESCRIPTION
#69

In the Looper Form of MeasFilterViews.enaml, test that the selected
filter is in the filter dictionary else return -1
#71

In the QtListStrWidget, test if the enable changed when the labels are the same
and the label is in the item list. Also, only signal a name change when the
labels are not the same and the newlabel is not in the item list. In the old
version of code there are some conditions when on_edit is called that result in
the dictionary manager trying to rename an item that does not exist.
#72

Added a new feature to save config in a different directory and load a config
from a different directory.  After loading a config, the GUI will restart itself
for the changes to take effectively
