### PR TITLE
Convert TAPulse to property to catch square pulses

### DIFF
--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -80,7 +80,6 @@ def merge_channels(wires, channels):
                 newentry = copy(entries[0])
                 #TODO properly deal with constant pulses
                 newentry.amp = 1.0
-                newentry.isTimeAmp = all([e.isTimeAmp for e in entries])
                 if all([e.amp == 0 for e in entries]):
                     newentry.amp = 0
                 else:
@@ -158,7 +157,6 @@ def concatenate_entries(entry1, entry2):
             return np.hstack((entry1.amp * np.exp(1j*entry1.phase) * entry1.shape,
                               entry2.amp * np.exp(1j*(entry1.frameChange + entry2.phase)) * entry2.shape))
 
-        newentry.isTimeAmp = False
         newentry.shapeParams = {'shapeFun' : stack_shapes}
         newentry.label = entry1.label + '+' + entry2.label
     newentry.frameChange += entry2.frameChange

--- a/QGL/PulseSequencer.py
+++ b/QGL/PulseSequencer.py
@@ -41,7 +41,6 @@ class Pulse(object):
         self.phase = phase
         self.amp = amp
         self.frameChange = frameChange
-        self.isTimeAmp = False
         requiredParams = ['length', 'shapeFun']
         for param in requiredParams:
             if param not in shapeParams.keys():
@@ -100,6 +99,10 @@ class Pulse(object):
         return self.amp == 0
 
     @property
+    def isTimeAmp(self):
+        return (self.shapeParams["shapeFun"] == PulseShapes.constant) or (self.shapeParams["shapeFun"] == PulseShapes.square)
+
+    @property
     def shape(self):
         params = copy(self.shapeParams)
         params['samplingRate'] = self.channel.physChan.samplingRate
@@ -112,7 +115,6 @@ def TAPulse(label, channel, length, amp, phase=0, frameChange=0):
     '''
     params = {'length': length, 'shapeFun': PulseShapes.constant}
     p = Pulse(label, channel, params, amp, phase, frameChange)
-    p.isTimeAmp = True
     return p
 
 class CompositePulse(object):


### PR DESCRIPTION
Would like to include isZero in isTimeAmp but becuase zero amp pulses hash the same as
non-zero amp pulse and they might not necessarily be the both time amp pairs.

with reporting and help from @matthewware 
