### PR TITLE
Force triggers to be left-aligned

### DIFF
--- a/QGL/Compiler.py
+++ b/QGL/Compiler.py
@@ -234,7 +234,6 @@ def compile_to_hardware(seqs, fileName, suffix=''):
     Compiles 'seqs' to a hardware description and saves it to 'fileName'. Other inputs:
         suffix : string to append to end of fileName (e.g. with fileNames = 'test' and suffix = 'foo' might save to test-APSfoo.h5)
     '''
-
     # Add the digitizer trigger to measurements
     PatternUtils.add_digitizer_trigger(seqs)
 
@@ -457,7 +456,7 @@ def schedule(channel, pulse, blockLength, alignment):
     if padLength == 0:
         # no padding element required
         return pulses
-    elif alignment == "left":
+    elif alignment == "left" or pulse.label == 'TRIG':
         return pulses + [Id(channel, padLength)]
     elif alignment == "right":
         return [Id(channel, padLength)] + pulses

--- a/QGL/PulseSequencer.py
+++ b/QGL/PulseSequencer.py
@@ -45,7 +45,7 @@ class Pulse(object):
         requiredParams = ['length', 'shapeFun']
         for param in requiredParams:
             if param not in shapeParams.keys():
-                raise NameError("ShapeParams must incluce {0}".format(param))
+                raise NameError("ShapeParams must include {0}".format(param))
 
     def __repr__(self):
         return str(self)


### PR DESCRIPTION
This prevents a digitizer trigger from being aligned with the other
pulses. For example, when center-aligning a measurement pulse with a
gate on another qubit. Not sure if this solution is too restrictive.
--DR
