### PR TITLE
roll library version numbers

### DIFF
--- a/MeasFilters.py
+++ b/MeasFilters.py
@@ -109,7 +109,7 @@ class MeasFilterLibrary(Atom):
     filterDict = Coerced(dict)
     libFile = Str().tag(transient=True)
     filterManager = Typed(DictManager)
-    version = Int(0)
+    version = Int(1)
 
     def __init__(self, **kwargs):
         super(MeasFilterLibrary, self).__init__(**kwargs)
@@ -123,9 +123,9 @@ class MeasFilterLibrary(Atom):
     def write_to_file(self,fileName=None):
         #Move import here to avoid circular import
         import JSONHelpers
-        
+
         libFileName = fileName if fileName != None else self.libFile
-        
+
         if libFileName:
             with open(libFileName, 'w') as FID:
                 json.dump(self, FID, cls=JSONHelpers.LibraryEncoder, indent=2, sort_keys=True)

--- a/QGL/Channels.py
+++ b/QGL/Channels.py
@@ -164,7 +164,7 @@ class Measurement(LogicalChannel):
     pulseParams = Dict(default={'length':100e-9, 'amp':1.0, 'shapeFun':PulseShapes.tanh, 'cutoff':2, 'sigma':1e-9})
     gateChan = Instance((unicode, LogicalMarkerChannel))
     trigChan = Instance((unicode, LogicalMarkerChannel))
-    
+
     def __init__(self, **kwargs):
         super(Measurement, self).__init__(**kwargs)
         if self.gateChan is None:
@@ -177,7 +177,7 @@ class Edge(LogicalChannel):
     Defines an arc/directed edge between qubit vertices. If a device supports bi-directional
     connectivity, that is represented with two independent Edges.
 
-    An Edge is also effectively an abstract channel, so it carries the same properties as a 
+    An Edge is also effectively an abstract channel, so it carries the same properties as a
     Qubit channel.
     '''
     # allow unicode in source and target so that we can store a label or an object
@@ -234,7 +234,7 @@ class ChannelLibrary(Atom):
     physicalChannelManager = Typed(DictManager)
     libFile = Str()
     fileWatcher = Typed(FileWatcher.LibraryFileWatcher)
-    version = Int(0)
+    version = Int(3)
 
     def __init__(self, channelDict={}, **kwargs):
         super(ChannelLibrary, self).__init__(channelDict=channelDict, **kwargs)

--- a/Sweeps.py
+++ b/Sweeps.py
@@ -128,7 +128,7 @@ class SweepLibrary(Atom):
     sweepList = Property()
     sweepOrder = List()
     possibleInstrs = List()
-    version = Int(0)
+    version = Int(1)
 
     sweepManager = Typed(DictManager)
 
@@ -149,9 +149,9 @@ class SweepLibrary(Atom):
 
     def write_to_file(self,fileName=None):
         import JSONHelpers
-        
+
         libFileName = fileName if fileName != None else self.libFile
-        
+
         if libFileName:
             with open(libFileName, 'w') as FID:
                 json.dump(self, FID, cls=JSONHelpers.LibraryEncoder, indent=2, sort_keys=True)

--- a/instruments/InstrumentManager.py
+++ b/instruments/InstrumentManager.py
@@ -38,7 +38,7 @@ class InstrumentLibrary(Atom):
     AWGs = Typed(DictManager)
     sources = Typed(DictManager)
     others = Typed(DictManager)
-    version = Int(0)
+    version = Int(3)
 
     fileWatcher = Typed(FileWatcher.LibraryFileWatcher)
 
@@ -52,7 +52,7 @@ class InstrumentLibrary(Atom):
         self.AWGs = DictManager(itemDict=self.instrDict,
                                 displayFilter=lambda x: isinstance(x, AWGs.AWG),
                                 possibleItems=AWGs.AWGList)
-        
+
         self.sources = DictManager(itemDict=self.instrDict,
                                    displayFilter=lambda x: isinstance(x, MicrowaveSources.MicrowaveSource),
                                    possibleItems=MicrowaveSources.MicrowaveSourceList)
@@ -73,11 +73,11 @@ class InstrumentLibrary(Atom):
             #Pause the file watcher to stop circular updating insanity
             if self.fileWatcher:
                 self.fileWatcher.pause()
-                
+
                 if libFileName:
                     with open(libFileName, 'w') as FID:
                         json.dump(self, FID, cls=JSONHelpers.LibraryEncoder, indent=2, sort_keys=True)
-            
+
             if self.fileWatcher:
                 self.fileWatcher.resume()
 
@@ -146,7 +146,7 @@ class InstrumentLibrary(Atom):
 
 if __name__ == '__main__':
 
-    
+
     from MicrowaveSources import AgilentN5183A
     instrLib = InstrumentLibrary(instrDict={'Agilent1':AgilentN5183A(label='Agilent1'), 'Agilent2':AgilentN5183A(label='Agilent2')})
     with enaml.imports():


### PR DESCRIPTION
After discussion with @bcdonovan I think these hard-coded version in the library managers need to be rolled as we upgrade.  Case example where it breaks:
1. Start with fresh repo.
2. Create an X6 using GUI. The instrument library version will be `0`.
3. Exit and relaunch the GUI.  The migrator will fail on [this line](https://github.com/BBN-Q/PyQLab/blob/5d04ef79a2b352a4853e2f85b6d365981d4b511e/LibraryMigrator.py#L132).

Our migrators are stateful and expect things to as they were in the previous version.  We could try and make the migrators more robust but I think the rolling the version number is the right thing to do.
