### PR TITLE
Fix APS2 instruction merging

### DIFF
--- a/tests/test_APS2Pattern.py
+++ b/tests/test_APS2Pattern.py
@@ -1,0 +1,51 @@
+import h5py
+import unittest
+import numpy as np
+from copy import copy
+
+from QGL import *
+from instruments.drivers import APS2Pattern
+
+class APSPatternUtils(unittest.TestCase):
+    def setUp(self):
+        self.q1gate = Channels.LogicalMarkerChannel(label='q1-gate')
+        self.q1 = Qubit(label='q1', gateChan=self.q1gate)
+        self.q1 = Qubit(label='q1')
+        self.q1.pulseParams['length'] = 30e-9
+
+        Compiler.channelLib = {'q1': self.q1, 'q1-gate': self.q1gate}
+
+    def test_synchronize_control_flow(self):
+        q1 = self.q1
+
+        pulse = Compiler.Waveform()
+        pulse.length = 24
+        pulse.key = 12345
+        delay = Compiler.Waveform()
+        delay.length = 100
+        delay.isTimeAmp = True
+        blank = Compiler.Waveform( BLANK(q1, pulse.length) )
+
+        seq_1 = [qwait(), delay, copy(pulse), qwait(), copy(pulse)]
+        seq_2 = [qwait(), copy(blank), qwait(), copy(blank)]
+        offsets = { APS2Pattern.wf_sig(pulse) : 0 }
+        
+        instructions = APS2Pattern.create_seq_instructions([seq_1, seq_2, [], [], []], offsets)
+
+        instr_types = [
+            APS2Pattern.SYNC,
+            APS2Pattern.WAIT,
+            APS2Pattern.WFM,
+            APS2Pattern.MARKER,
+            APS2Pattern.WFM,
+            APS2Pattern.WAIT,
+            APS2Pattern.WFM,
+            APS2Pattern.MARKER
+        ]
+
+        for actual, expected in zip(instructions, instr_types):
+            instrOpCode = (actual.header >> 4) & 0xf
+            assert(instrOpCode == expected)
+
+if __name__ == "__main__":    
+    unittest.main()


### PR DESCRIPTION
Fixes issue #90.

The strategy here is just to ensure that **all** control-flow instructions are synchronous. This basically boils down to re-labeling the start times of such instructions to the max across the various waveform and marker sequences. This happens to also simplify some logic inside `create_seq_instructions()`.
