### PR TITLE
Fix phase comparison (modulo 2 pi)

### DIFF
--- a/QGL/PatternUtils.py
+++ b/QGL/PatternUtils.py
@@ -216,9 +216,10 @@ def propagate_frame_changes(seq):
         else:
             frame[-1] += updateFrame
     if frame:
-        if sum(np.array(frame)-frame[0])!=0 and not (isinstance(seq[-2], BlockLabel.BlockLabel) and isinstance(seq[-1], ControlFlow.Goto)): 
+        frame = np.mod(frame,2*np.pi)
+        if not np.isclose(frame, frame[0]).all() and not (isinstance(seq[-2], BlockLabel.BlockLabel) and isinstance(seq[-1], ControlFlow.Goto)): 
         #all phases must be equal at the end of each branch, unless the sequence is over
-            raise Exception("Branches have different lengths. Phases of following pulses are not consistent.")
+            raise Exception("Branches have different final phases. Phases of following pulses are not consistent.")
     return seq
 
 def quantize_phase(seqs, precision):


### PR DESCRIPTION
Include rounding errors.
Message better reflects the error. It is ok to have branches of
different lengths if their cumulative phases are the same (for example
if all pulses are an integer number of the SSB period).
--DR
