### PR TITLE
Feature/flexible instr types

### DIFF
--- a/ChannelsViews.enaml
+++ b/ChannelsViews.enaml
@@ -68,7 +68,7 @@ enamldef PhysicalMarkerChannelView(GroupBox): curView:
         Label:
             text = 'AWG'
         ComboBox:
-            items << instrumentLib.AWGs.displayList + instrumentLib.pseudoAWGs.displayList
+            items << instrumentLib.AWGs.displayList + instrumentLib.markedInstrs.displayList
             index = items.index(chan.AWG) if chan.AWG in items else -1
             index ::
                 chan.AWG = selected_item

--- a/ChannelsViews.enaml
+++ b/ChannelsViews.enaml
@@ -68,7 +68,7 @@ enamldef PhysicalMarkerChannelView(GroupBox): curView:
         Label:
             text = 'AWG'
         ComboBox:
-            items << instrumentLib.AWGs.displayList
+            items << instrumentLib.AWGs.displayList + instrumentLib.pseudoAWGs.displayList
             index = items.index(chan.AWG) if chan.AWG in items else -1
             index ::
                 chan.AWG = selected_item

--- a/instruments/InstrumentManager.py
+++ b/instruments/InstrumentManager.py
@@ -36,7 +36,7 @@ class InstrumentLibrary(Atom):
 
     #Some helpers to manage types of instruments
     AWGs = Typed(DictManager)
-    pseudoAWGs = Typed(DictManager)
+    markedInstrs = Typed(DictManager)
     sources = Typed(DictManager)
     others = Typed(DictManager)
     version = Int(3)
@@ -54,11 +54,6 @@ class InstrumentLibrary(Atom):
                                 displayFilter=lambda x: isinstance(x, AWGs.AWG),
                                 possibleItems=AWGs.AWGList)
 
-        # To enable routing physical marker channels to more generic devices
-        self.pseudoAWGs = DictManager(itemDict=self.instrDict,
-                                displayFilter=lambda x: hasattr(x, 'channel_type') and x.channel_type == 'AWG',
-                                possibleItems=newOtherInstrs)
-
         self.sources = DictManager(itemDict=self.instrDict,
                                    displayFilter=lambda x: isinstance(x, MicrowaveSources.MicrowaveSource),
                                    possibleItems=MicrowaveSources.MicrowaveSourceList)
@@ -66,6 +61,11 @@ class InstrumentLibrary(Atom):
         self.others = DictManager(itemDict=self.instrDict,
                                   displayFilter=lambda x: not isinstance(x, AWGs.AWG) and not isinstance(x, MicrowaveSources.MicrowaveSource),
                                   possibleItems=newOtherInstrs)
+
+        # To enable routing physical marker channels to more generic devices
+        self.markedInstrs = DictManager(itemDict=self.instrDict,
+                                displayFilter=lambda x: not isinstance(x, AWGs.AWG) and hasattr(x, 'takes_marker') and x.takes_marker,
+                                possibleItems=newOtherInstrs)
 
     #Overload [] to allow direct pulling out of an instrument
     def __getitem__(self, instrName):

--- a/instruments/InstrumentManager.py
+++ b/instruments/InstrumentManager.py
@@ -36,6 +36,7 @@ class InstrumentLibrary(Atom):
 
     #Some helpers to manage types of instruments
     AWGs = Typed(DictManager)
+    pseudoAWGs = Typed(DictManager)
     sources = Typed(DictManager)
     others = Typed(DictManager)
     version = Int(3)
@@ -52,6 +53,11 @@ class InstrumentLibrary(Atom):
         self.AWGs = DictManager(itemDict=self.instrDict,
                                 displayFilter=lambda x: isinstance(x, AWGs.AWG),
                                 possibleItems=AWGs.AWGList)
+
+        # To enable routing physical marker channels to more generic devices
+        self.pseudoAWGs = DictManager(itemDict=self.instrDict,
+                                displayFilter=lambda x: hasattr(x, 'channel_type') and x.channel_type == 'AWG',
+                                possibleItems=newOtherInstrs)
 
         self.sources = DictManager(itemDict=self.instrDict,
                                    displayFilter=lambda x: isinstance(x, MicrowaveSources.MicrowaveSource),


### PR DESCRIPTION
The current model has a rather rigid conception of what an AWG can do vs. Digitizers vs. EverythingElse. The PR allows physical marker channels to point to a broader class of instruments or channels. An instrument class declaring `takes_marker == True` will show up as a possible "AWG" in the GUI (despite the potential misnomer).
