### PR TITLE
WIP: Auto populate physical channels

### DIFF
--- a/DictManager.py
+++ b/DictManager.py
@@ -13,6 +13,7 @@ class DictManager(Atom):
     possibleItems = List() # a list of classes that can possibly be added to this list
     displayList = ContainerList()
     onChangeDelegate = Callable()
+    otherActions = Dict(Unicode(), Callable())
 
     def __init__(self, itemDict={}, displayFilter=lambda x: True, **kwargs):
         self.displayFilter = displayFilter

--- a/DictManagerView.enaml
+++ b/DictManagerView.enaml
@@ -6,6 +6,7 @@ from widgets import QtListStrWidget
 from enaml.widgets.api import Window, Container, PushButton, Form, Label, Field, ComboBox
 from enaml.stdlib.mapped_view import MappedView
 from enaml.core.declarative import d_
+from enaml.core.api import Looper
 
 from enaml.layout.api import hbox, vbox, spacer
 
@@ -24,7 +25,7 @@ enamldef DictManagerView(Container): dictView:
 		hbox(
 			vbox(
 				itemList,
-				hbox(addButton, removeButton, spacer),
+				hbox(addButton, removeButton, *sum(otherButtons.items, [spacer])),
 				spacer
 				),
 			selectedItemView,
@@ -46,6 +47,11 @@ enamldef DictManagerView(Container): dictView:
 	PushButton: removeButton:
 		text = "Remove"
 		clicked :: dictManager.remove_item(itemList.selected_item)
+	Looper: otherButtons:
+		iterable << dictManager.otherActions.keys()
+		PushButton:
+			text = loop_item
+			clicked :: dictManager.otherActions[loop_item]()
 	Container: selectedItemView:
 		MappedView:
 			model << dictManager.itemDict[itemList.selected_item] if itemList.selected_item else None

--- a/DictManagerView.enaml
+++ b/DictManagerView.enaml
@@ -35,8 +35,8 @@ enamldef DictManagerView(Container): dictView:
 	QtListStrWidget: itemList:
 		items := dictManager.displayList
 		validator = labelValidator
-		checked_states = [dictManager.itemDict[i].enabled for i in dictManager.displayList]
-		initialized :: 
+		checked_states << [dictManager.itemDict[i].enabled for i in dictManager.displayList]
+		initialized ::
 			itemList.item_changed.connect(dictManager.name_changed)
 			itemList.enable_changed.connect(dictManager.update_enable)
 
@@ -47,9 +47,8 @@ enamldef DictManagerView(Container): dictView:
 		text = "Remove"
 		clicked :: dictManager.remove_item(itemList.selected_item)
 	Container: selectedItemView:
-		MappedView: 
+		MappedView:
 			model << dictManager.itemDict[itemList.selected_item] if itemList.selected_item else None
 			typemap = dictView.viewMap
 			modelkey = dictView.modelName
 			kwargs = dictView.viewkwargs if dictView.viewkwargs else {}
-

--- a/ExpSettingsGUI.py
+++ b/ExpSettingsGUI.py
@@ -182,7 +182,6 @@ class ExpSettings(Atom):
                 pc.translator = instr.translator
                 pc.samplingRate = instr.samplingRate
                 self.channels[label] = pc
-        print self.channels.channelDict
         self.physicalChannelManager.update_display_list(None)
 
 

--- a/ExpSettingsGUI.py
+++ b/ExpSettingsGUI.py
@@ -164,22 +164,26 @@ class ExpSettings(Atom):
     def format_errors(self):
         return '\n'.join(self.validation_errors)
 
-    def populate_physical_channels(self, awg):
-        channels = awg.get_naming_convention()
-        for ch in channels:
-            label = awg.label + '-' + ch
-            if label in self.channels:
-                continue
-            # TODO: less kludgy lookup of appropriate channel type
-            if 'm' in ch.lower():
-                pc = QGL.Channels.PhysicalMarkerChannel()
-            else:
-                pc = QGL.Channels.PhysicalQuadratureChannel()
-            pc.label = label
-            pc.AWG = awg.label
-            pc.translator = awg.translator
-            pc.samplingRate = awg.samplingRate
-            self.channels[label] = pc
+    def populate_physical_channels(self, awgs=None):
+        import instruments.AWGs
+        if awgs == None:
+            awgs = filter(lambda x: isinstance(x, instruments.AWGs.AWG), self.instruments.instrDict.values())
+        for awg in awgs:
+            channels = awg.get_naming_convention()
+            for ch in channels:
+                label = awg.label + '-' + ch
+                if label in self.channels:
+                    continue
+                # TODO: less kludgy lookup of appropriate channel type
+                if 'm' in ch.lower():
+                    pc = QGL.Channels.PhysicalMarkerChannel()
+                else:
+                    pc = QGL.Channels.PhysicalQuadratureChannel()
+                pc.label = label
+                pc.AWG = awg.label
+                pc.translator = awg.translator
+                pc.samplingRate = awg.samplingRate
+                self.channels[label] = pc
         self.physicalChannelManager.update_display_list(None)
 
 

--- a/ExpSettingsGUI.py
+++ b/ExpSettingsGUI.py
@@ -162,6 +162,30 @@ class ExpSettings(Atom):
     def format_errors(self):
         return '\n'.join(self.validation_errors)
 
+    def populate_physical_channels(self):
+        import instruments.AWGs
+        for instr in self.instruments.instrDict.values():
+            if not isinstance(instr, instruments.AWGs.AWG):
+                continue
+            channels = instr.get_naming_convention()
+            for ch in channels:
+                label = instr.label + '-' + ch
+                if label in self.channels:
+                    continue
+                # TODO: less kludgy lookup of appropriate channel type
+                if 'm' in ch.lower():
+                    pc = QGL.Channels.PhysicalMarkerChannel()
+                else:
+                    pc = QGL.Channels.PhysicalQuadratureChannel()
+                pc.label = label
+                pc.AWG = instr.label
+                pc.translator = instr.translator
+                pc.samplingRate = instr.samplingRate
+                self.channels[label] = pc
+        print self.channels.channelDict
+        self.physicalChannelManager.update_display_list(None)
+
+
 class ScripterEncoder(json.JSONEncoder):
     """
     Helper for QLab to encode all the classes for the matlab experiment script.

--- a/ExpSettingsGUI.py
+++ b/ExpSettingsGUI.py
@@ -50,7 +50,8 @@ class ExpSettings(Atom):
         self.physicalChannelManager = DictManager(
             itemDict = self.channels.channelDict,
             displayFilter = lambda x : isinstance(x, QGL.Channels.PhysicalChannel),
-            possibleItems = QGL.Channels.NewPhysicalChannelList
+            possibleItems = QGL.Channels.NewPhysicalChannelList,
+            otherActions = {"Auto": self.populate_physical_channels}
         )
 
     # TODO: get this to work

--- a/ExpSettingsView.enaml
+++ b/ExpSettingsView.enaml
@@ -59,7 +59,7 @@ enamldef NotificationPopup(PopupView):
 
 enamldef ErrorPopup(Window): error_win:
     title = 'Validation Error'
-    modality = 'application_modal' 
+    modality = 'application_modal'
     attr displayText = ''
 
     Container:
@@ -92,7 +92,7 @@ enamldef ExpSettingsView(MainWindow): main:
 						ep = ErrorPopup(displayText=expSettings.format_errors())
 						ep.show()
 						ep.center_on_widget(main)
-						
+
 			Action:
 				text = 'Save Config As\tCtrl+Shift+S'
 				tool_tip = 'Save to a new setting file'
@@ -101,14 +101,14 @@ enamldef ExpSettingsView(MainWindow): main:
 					if not os.path.isdir(path) and path !='':
 						print('% s Does not Exist: Creating %s'%(path,path))
 						os.mkdir(path)
-					
+
 					if expSettings.save_config(path):
 						NotificationPopup(main, window_type='window', displayText="Config Saved").show()
 					else:
 						ep = ErrorPopup(displayText=expSettings.format_errors())
 						ep.show()
 						ep.center_on_widget(main)
-			
+
 			Action:
 				text = 'Load Config\tCtrl+Shift+O'
 				tool_tip = 'Load Config Files from Saved Location'
@@ -120,16 +120,16 @@ enamldef ExpSettingsView(MainWindow): main:
 						ep.show()
 						ep.center_on_widget(main)
 						os.mkdir(path)
-					
+
 					if expSettings.load_config(path):
 						NotificationPopup(main, window_type='window', displayText="New Config Loaded ... Restarting GUI").show()
 						os.execl(sys.executable, sys.executable, * sys.argv)
-						
+
 					else:
 						ep = ErrorPopup(displayText=expSettings.format_errors())
 						ep.show()
 						ep.center_on_widget(main)
-						
+
 			Action:
 				text = "Stash current settings"
 				enabled = False
@@ -140,10 +140,6 @@ enamldef ExpSettingsView(MainWindow): main:
 				enabled = False
 				triggered ::
 					NotificationPopup(main, window_type='window', displayText="Stashed settings applied").show()
-			Action:
-				text = "Populate physical channels"
-				triggered ::
-					expSettings.populate_physical_channels()
 			Action:
 				text = 'Store to quick pick\tCtrl+O'
 				enabled = False

--- a/ExpSettingsView.enaml
+++ b/ExpSettingsView.enaml
@@ -141,10 +141,6 @@ enamldef ExpSettingsView(MainWindow): main:
 				triggered ::
 					NotificationPopup(main, window_type='window', displayText="Stashed settings applied").show()
 			Action:
-				text = "Populate physical channels"
-				triggered ::
-					expSettings.populate_physical_channels()
-			Action:
 				text = 'Store to quick pick\tCtrl+O'
 				enabled = False
 				triggered :: print 'clicked store to quick pick'

--- a/ExpSettingsView.enaml
+++ b/ExpSettingsView.enaml
@@ -141,6 +141,10 @@ enamldef ExpSettingsView(MainWindow): main:
 				triggered ::
 					NotificationPopup(main, window_type='window', displayText="Stashed settings applied").show()
 			Action:
+				text = "Populate physical channels"
+				triggered ::
+					expSettings.populate_physical_channels()
+			Action:
 				text = 'Store to quick pick\tCtrl+O'
 				enabled = False
 				triggered :: print 'clicked store to quick pick'

--- a/instruments/InstrumentManager.py
+++ b/instruments/InstrumentManager.py
@@ -50,7 +50,7 @@ class AWGDictManager(DictManager):
                 self.itemDict[dialogBox.newLabel] = self.possibleItems[dialogBox.newModelNum](label=dialogBox.newLabel)
                 self.displayList.append(dialogBox.newLabel)
                 if dialogBox.auto_populate_channels and self.populate_physical_channels is not None:
-                    self.populate_physical_channels(self.itemDict[dialogBox.newLabel])
+                    self.populate_physical_channels([self.itemDict[dialogBox.newLabel]])
             else:
                 print("WARNING: Can't use duplicate label %s"%dialogBox.newLabel)
 

--- a/instruments/InstrumentManagerView.enaml
+++ b/instruments/InstrumentManagerView.enaml
@@ -53,7 +53,7 @@ enamldef InstrumentManagerView(Container):
 				viewMap = MicrowaveSourceViewMap
 				modelName = 'uwSource'
 				labelValidator = is_valid_instrument_name
-		
+
 		Page:
 			title = "AWG's"
 			closable = False
@@ -63,7 +63,7 @@ enamldef InstrumentManagerView(Container):
 				modelName = 'awg'
 				viewkwargs = {'instrumentLib': instrLib.instrDict}
 				labelValidator = is_valid_instrument_name
-		
+
 		Page:
 			title = "Other"
 			closable = False
@@ -74,10 +74,8 @@ enamldef InstrumentManagerView(Container):
 				viewkwargs = {'instrumentLib': instrLib.instrDict}
 				labelValidator = is_valid_instrument_name
 
-enamldef InstrumentManagerWindow(Window): 
+enamldef InstrumentManagerWindow(Window):
 	attr instrLib
 	title = 'Instrument Library'
 	InstrumentManagerView:
 		instrLib = parent.instrLib
-
-

--- a/widgets/dialogs.enaml
+++ b/widgets/dialogs.enaml
@@ -1,4 +1,4 @@
-from enaml.widgets.api import Dialog, Label, Field, ComboBox
+from enaml.widgets.api import Dialog, Label, Field, ComboBox, Form, CheckBox
 
 from enaml.layout.api import hbox, vbox, spacer
 
@@ -22,9 +22,42 @@ enamldef ItemSelector(TaskDialogContentArea):
 
 enamldef DialogBody(TaskDialogBody):
 	alias itemSelector: itemSelector
-	attr objText 
+	attr objText
 	attr modelNames
 	ItemSelector: itemSelector:
+		newLabel = "New"+objText
+		modelNames = parent.modelNames
+	TaskDialogCommandArea:
+		constraints = [ hbox(spacer, bbox) ]
+		DialogButtonBox: bbox:
+			buttons = [
+				DialogButton('OK', 'accept'),
+				DialogButton('Cancel', 'reject'),
+			]
+
+enamldef AWGItemSelector(TaskDialogContentArea):
+	alias newLabel: newLabelField.text
+	alias newModelNum: newModelBox.index
+	alias auto_populate_channels: auto_populate_channels_checkbox.checked
+	attr modelNames
+	Form:
+		Label:
+			text = "New Label"
+		Field: newLabelField:
+			pass
+		Label:
+			text = "New Model"
+		ComboBox: newModelBox:
+			index = 0
+			items = modelNames
+	CheckBox: auto_populate_channels_checkbox:
+		text = "Auto-populate channels"
+
+enamldef AWGDialogBody(TaskDialogBody):
+	alias itemSelector: itemSelector
+	attr objText
+	attr modelNames
+	AWGItemSelector: itemSelector:
 		newLabel = "New"+objText
 		modelNames = parent.modelNames
 	TaskDialogCommandArea:
@@ -46,7 +79,17 @@ enamldef AddItemDialog(Dialog):
 		objText = parent.objText
 		modelNames = parent.modelNames
 
-
+enamldef AddAWGDialog(Dialog):
+	attr modelNames
+	attr objText
+	alias newLabel: dialogBody.itemSelector.newLabel
+	alias newModelNum: dialogBody.itemSelector.newModelNum
+	alias auto_populate_channels: dialogBody.itemSelector.auto_populate_channels
+	# alias newLabel: dialogBody.contentArea.newLabelField
+	title = 'Add a new {}...'.format(objText)
+	AWGDialogBody: dialogBody:
+		objText = parent.objText
+		modelNames = parent.modelNames
 
 # enamldef AddDialog(Window):
 # 	attr newClassList


### PR DESCRIPTION
Adds a menu item to automatically populate the physical channel library from the AWGs in the instrument library. Some improvements from here would be:
- [x] Add a button to the physical channels tab to trigger the action
- [ ] Modify `get_naming_convention` to include type of each channel, so that we have a better way to distinguish marking channels from quadrature channels.
