### PR TITLE
Load QGL meta info files.

### DIFF
--- a/ExpSettingsGUI.py
+++ b/ExpSettingsGUI.py
@@ -130,36 +130,6 @@ class ExpSettings(Atom):
 
         return True
 
-
-    def apply_quickpick(self, name):
-        try:
-            with open(config.quickpickFile, 'r') as FID:
-                quickPicks = json.load(FID)
-        except IOError:
-            print('No quick pick file found.')
-            return
-
-        quickPick = quickPicks[name]
-
-        #Apply sequence name
-        if 'seqFile' in quickPick and 'seqDir' in quickPick:
-            for awgName in self.instruments.AWGs.displayList:
-                self.instruments[awgName].seqFile = os.path.normpath(os.path.join(config.AWGDir, quickPick['seqDir'],
-                                 '{}-{}{}'.format(quickPick['seqFile'], awgName, self.instruments[awgName].seqFileExt)))
-
-        #Apply sweep info
-        if 'sweeps' in quickPick:
-            for sweep in quickPick['sweeps']:
-                if sweep in self.sweeps.sweepDict:
-                    for k,v in quickPick['sweeps'][sweep].items():
-                        setattr(self.sweeps.sweepDict[sweep], k, v)
-        if 'sweepOrder' in quickPick:
-            self.sweeps.sweepOrder = quickPick['sweepOrder']
-
-        #Setup the digitizer number of segments
-        if 'nbrSegments' in quickPick:
-            self.instruments['scope'].nbrSegments = quickPick['nbrSegments']
-
     def load_meta(self):
         meta_file = self.meta_file
         if not os.path.isfile(meta_file):

--- a/ExpSettingsView.enaml
+++ b/ExpSettingsView.enaml
@@ -35,7 +35,7 @@ enamldef NotificationPopup(PopupView):
 			align = 'center'
 
 enamldef ErrorPopup(Window): error_win:
-    title = 'Validation Error'
+    title = 'Error!'
     modality = 'application_modal'
     attr displayText = ''
 
@@ -79,10 +79,14 @@ enamldef ExpSettingsView(MainWindow): main:
 						print('% s Does not Exist: Creating %s'%(path,path))
 						os.mkdir(path)
 
-					if expSettings.save_config(path):
+					try:
+						expSettings.save_config(path)
 						NotificationPopup(main, window_type='window', displayText="Config Saved").show()
-					else:
-						ep = ErrorPopup(displayText=expSettings.format_errors())
+					except Exception as e:
+						err_str = expSettings.format_errors()
+						if not err_str:
+							err_str = e.message
+						ep = ErrorPopup(displayText=err_str)
 						ep.show()
 						ep.center_on_widget(main)
 
@@ -98,12 +102,15 @@ enamldef ExpSettingsView(MainWindow): main:
 						ep.center_on_widget(main)
 						os.mkdir(path)
 
-					if expSettings.load_config(path):
+					try:
+						expSettings.load_config(path)
 						NotificationPopup(main, window_type='window', displayText="New Config Loaded ... Restarting GUI").show()
 						os.execl(sys.executable, sys.executable, * sys.argv)
-
-					else:
-						ep = ErrorPopup(displayText=expSettings.format_errors())
+					except Exception as e:
+						err_str = expSettings.format_errors()
+						if not err_str:
+							err_str = e.message
+						ep = ErrorPopup(displayText=err_str)
 						ep.show()
 						ep.center_on_widget(main)
 
@@ -174,14 +181,22 @@ enamldef ExpSettingsView(MainWindow): main:
 			PushButton: meta_button:
 				text = "Load"
 				clicked ::
-					expSettings.load_meta()
-					NotificationPopup(
-						main,
-						window_type='window',
-						parent_anchor=(0, 1.0),
-						anchor=(0,1),
-						offset=(10,-10),
-						displayText="Meta file info loaded").show()
+					try:
+						expSettings.load_meta()
+						NotificationPopup(
+							main,
+							window_type='window',
+							parent_anchor=(0, 1.0),
+							anchor=(0,1),
+							offset=(10,-10),
+							displayText="Meta file info loaded").show()
+					except Exception as e:
+						err_str = expSettings.format_errors()
+						if not err_str:
+							err_str = e.message
+						ep = ErrorPopup(displayText=err_str)
+						ep.show()
+						ep.center_on_widget(main)
 		Form: cbValidateForm:
 			Label:
 				text = "Validate"
@@ -191,9 +206,13 @@ enamldef ExpSettingsView(MainWindow): main:
 			text = 'Apply'
 			clicked ::
 				expSettings.write_to_file()
-				if expSettings.write_libraries():
+				try:
+					expSettings.write_libraries()
 					NotificationPopup(main, window_type='window', displayText="Settings saved").show()
-				else:
-					ep = ErrorPopup(displayText=expSettings.format_errors())
+				except Exception as e:
+					err_str = expSettings.format_errors()
+					if not err_str:
+						err_str = e.message
+					ep = ErrorPopup(displayText=err_str)
 					ep.show()
 					ep.center_on_widget(main)

--- a/ExpSettingsView.enaml
+++ b/ExpSettingsView.enaml
@@ -10,35 +10,12 @@ from SweepsViews import SweepManager
 from MeasFiltersViews import MeasFilterManager
 import os, sys, time
 
-
-#See what's in the quick pick file to enumerate it
-import config, json
-try:
-    with open(config.quickpickFile, 'r') as FID:
-        quickPicks = json.load(FID)
-        quickpickList = quickPicks.keys()
-except IOError:
-    print('No quick pick file found.')
-    quickpickList = []
-
 def get_update_script_file_callback(expSettings):
 	def update_script_file_callback(dlg):
 		if dlg.result == 'accepted': #if the pressed "open" otherwise we get 'rejected'
 			expSettings.curFileName = dlg.path
 			print(expSettings.curFileName)
 	return update_script_file_callback
-
-chosenQuickPick = bytearray("")
-
-enamldef QuickPickMenu(Menu):
-	attr expSettings
-	Looper:
-		iterable << quickpickList
-		Action:
-			text = loop_item
-			triggered ::
-				chosenQuickPick[:] = bytearray(loop_item.encode("ascii"))
-				expSettings.apply_quickpick(loop_item)
 
 enamldef NotificationPopup(PopupView):
 	attr displayText = ''
@@ -141,19 +118,6 @@ enamldef ExpSettingsView(MainWindow): main:
 				triggered ::
 					NotificationPopup(main, window_type='window', displayText="Stashed settings applied").show()
 			Action:
-				text = 'Store to quick pick\tCtrl+O'
-				enabled = False
-				triggered :: print 'clicked store to quick pick'
-			Menu:
-				title = 'Load from quick pick'
-				Looper:
-					iterable << quickpickList
-					Action:
-						text = loop_item
-						triggered ::
-							chosenQuickPick[:] = bytearray(loop_item.encode("ascii"))
-							expSettings.apply_quickpick(loop_item)
-			Action:
 				text = 'Quit\tCtrl+Q'
 				triggered :: main.close()
 		Menu:
@@ -171,9 +135,9 @@ enamldef ExpSettingsView(MainWindow): main:
 		constraints = [
 			vbox(
 			tabs,
-			hbox(quickPick, exp_meta_info, spacer, cbValidateForm, settingsApply)
+			hbox(exp_meta_info, spacer, cbValidateForm, settingsApply)
 			),
-			align("v_center", quickPick, exp_meta_info, cbValidateForm, settingsApply )
+			align("v_center", exp_meta_info, cbValidateForm, settingsApply )
 		]
 		padding = 5
 		Notebook: tabs:
@@ -201,11 +165,6 @@ enamldef ExpSettingsView(MainWindow): main:
 				closable = False
 				SweepManager:
 					sweepLib := expSettings.sweeps
-		PushButton: quickPick:
-			text = "QuickPick"
-			clicked ::
-				QuickPickMenu(expSettings=expSettings).popup()
-				NotificationPopup(main, window_type='window', parent_anchor=(0, 1.0), anchor=(0,1), offset=(10,-10), displayText="{} applied".format(str(chosenQuickPick))).show()
 		GroupBox: exp_meta_info:
 			constraints = [hbox(meta_label, meta_field, meta_button)]
 			Label: meta_label:
@@ -214,7 +173,15 @@ enamldef ExpSettingsView(MainWindow): main:
 				text := expSettings.meta_file
 			PushButton: meta_button:
 				text = "Load"
-				clicked :: expSettings.load_meta()
+				clicked ::
+					expSettings.load_meta()
+					NotificationPopup(
+						main,
+						window_type='window',
+						parent_anchor=(0, 1.0),
+						anchor=(0,1),
+						offset=(10,-10),
+						displayText="Meta file info loaded").show()
 		Form: cbValidateForm:
 			Label:
 				text = "Validate"

--- a/ExpSettingsView.enaml
+++ b/ExpSettingsView.enaml
@@ -1,6 +1,6 @@
 from enaml.widgets.api import MainWindow, Window, Container, Notebook, Page, MenuBar, \
 					 Menu, Action, FileDialogEx, ComboBox, PushButton, PopupView, Label, \
-					 CheckBox, Form
+					 CheckBox, Form, Field, GroupBox
 from enaml.core.api import Looper
 from enaml.layout.api import hbox, vbox, spacer, align
 
@@ -171,9 +171,9 @@ enamldef ExpSettingsView(MainWindow): main:
 		constraints = [
 			vbox(
 			tabs,
-			hbox(quickPick, spacer, cbValidateForm, settingsApply)
+			hbox(quickPick, exp_meta_info, spacer, cbValidateForm, settingsApply)
 			),
-			align("v_center", quickPick, cbValidateForm, settingsApply )
+			align("v_center", quickPick, exp_meta_info, cbValidateForm, settingsApply )
 		]
 		padding = 5
 		Notebook: tabs:
@@ -206,6 +206,15 @@ enamldef ExpSettingsView(MainWindow): main:
 			clicked ::
 				QuickPickMenu(expSettings=expSettings).popup()
 				NotificationPopup(main, window_type='window', parent_anchor=(0, 1.0), anchor=(0,1), offset=(10,-10), displayText="{} applied".format(str(chosenQuickPick))).show()
+		GroupBox: exp_meta_info:
+			constraints = [hbox(meta_label, meta_field, meta_button)]
+			Label: meta_label:
+				text = "Exp Meta File"
+			Field: meta_field:
+				text := expSettings.meta_file
+			PushButton: meta_button:
+				text = "Load"
+				clicked :: expSettings.load_meta()
 		Form: cbValidateForm:
 			Label:
 				text = "Validate"

--- a/Sweeps.py
+++ b/Sweeps.py
@@ -147,6 +147,12 @@ class SweepLibrary(Atom):
     def __getitem__(self, sweepName):
         return self.sweepDict[sweepName]
 
+    def __contains__(self, key):
+        return key in self.sweepDict
+
+    def __iter__(self):
+        return iter(self.sweepDict)
+
     def _get_sweepList(self):
         return [sweep.label for sweep in self.sweepDict.values() if sweep.enabled]
 

--- a/config.py
+++ b/config.py
@@ -28,4 +28,3 @@ AWGDir = os.path.abspath(PyQLabCfg['AWGDir'])
 instrumentLibFile = os.path.abspath(PyQLabCfg['InstrumentLibraryFile'])
 sweepLibFile = os.path.abspath(PyQLabCfg['SweepLibraryFile'])
 measurementLibFile = os.path.abspath(PyQLabCfg['MeasurementLibraryFile'])
-quickpickFile = os.path.abspath(PyQLabCfg['QuickPickFile']) if 'QuickPickFile' in PyQLabCfg else ''

--- a/instruments/Digitizers.py
+++ b/instruments/Digitizers.py
@@ -12,7 +12,7 @@ from enaml.qt.qt_application import QtApplication
 class Digitizer(Instrument):
 	pass
 
-class AlazarATS9870(Instrument):
+class AlazarATS9870(Digitizer):
 	address = Str('1').tag(desc='Location of the card') #For now we only have one
 	acquireMode = Enum('digitizer', 'averager').tag(desc='Whether the card averages on-board or returns single-shot data')
 	clockType = Enum('ref')
@@ -85,7 +85,7 @@ class X6VirtualChannel(Atom):
 				jsonDict['rawKernelBias'] = []
 		return jsonDict
 
-class X6(Instrument):
+class X6(Digitizer):
 	recordLength = Int(1024).tag(desc='Number of samples in each record')
 	nbrSegments = Int(1).tag(desc='Number of segments in memory')
 	nbrWaveforms = Int(1).tag(desc='Number of times each segment is repeated')

--- a/instruments/InstrumentManager.py
+++ b/instruments/InstrumentManager.py
@@ -97,6 +97,9 @@ class InstrumentLibrary(Atom):
     def __getitem__(self, instrName):
         return self.instrDict[instrName]
 
+    def __contains__(self, key):
+        return key in self.instrDict
+
     def write_to_file(self,fileName=None):
         libFileName = fileName if fileName != None else self.libFile
         if self.libFile:


### PR DESCRIPTION
Adds a group box to the bottom of ExpSettingsGUI that accepts a full file path, or a `compile_to_hardware` style path like `T1/T1` tries to find the corresponding file inside of `AWGDir`.
