### PR TITLE
enable used AWGs in loading meta

### DIFF
--- a/ExpSettingsGUI.py
+++ b/ExpSettingsGUI.py
@@ -130,11 +130,15 @@ class ExpSettings(Atom):
             self.errors.append('Meta info file not found')
             raise IOError
         # load sequence files into AWGs
+        for awg in self.instruments.AWGs.displayList:
+            self.instruments[awg].enabled = False
         for instr, seqFile in meta_info['instruments'].items():
             if instr not in self.instruments:
                 self.errors.append("{} not found".format(instr))
                 raise KeyError
             self.instruments[instr].seqFile = seqFile
+            self.instruments[instr].enabled = True
+        self.instruments.AWGs.update_display_list(None)
 
         # setup up digitizers with number of segments
         for instr in self.instruments.instrDict.values():

--- a/widgets/qt_list_str_widget.py
+++ b/widgets/qt_list_str_widget.py
@@ -146,28 +146,40 @@ class QtListStrWidget(RawWidget):
     # Observers
     #--------------------------------------------------------------------------
     @observe('items')
-    def _update_proxy(self, change):
-        """ An observer which sends state change to the proxy.
+    def _update_items(self, change):
+        """ An observer which sends state change to the proxy. """
 
-        """
-        # The superclass handler implementation is sufficient.
+        #this callback may be called before the widget is initialized
         widget = self.get_widget()
-        if widget != None:
-            if change["name"] == "items":
-                if change["type"] == "update":
-                    if len(change["oldvalue"]) > len(change["value"]):
-                        # We've lost an item
-                        removedKey = set(change["oldvalue"]) - set(change["value"])
-                        removedIndex = change["oldvalue"].index(list(removedKey)[0])
-                        del self.checked_states[removedIndex]
-                    elif len(change["oldvalue"]) < len(change["value"]):
-                        self.checked_states.append(True)
+        if widget == None:
+            return
 
-            self.set_items(self.items)
+        if (change["name"] == "items") and (change["type"] == "update"):
+            if len(change["oldvalue"]) > len(change["value"]):
+                # We've lost an item
+                removedKey = set(change["oldvalue"]) - set(change["value"])
+                removedIndex = change["oldvalue"].index(list(removedKey)[0])
+                del self.checked_states[removedIndex]
+            elif len(change["oldvalue"]) < len(change["value"]):
+                self.checked_states.append(True)
 
-            # update the selected item because the current row has changed
-            self.selected_item = self.items[widget.currentRow()] if self.selected_index >= 0 else u''
+        self.set_items(self.items)
 
+        # update the selected item because the current row has changed
+        self.selected_item = self.items[widget.currentRow()] if self.selected_index >= 0 else u''
+
+    @observe('checked_states')
+    def _update_enabled_check_boxes(self, change):
+
+        #this callback may be called before the widget is initialized
+        widget = self.get_widget()
+        if widget == None:
+            return
+
+        if change["name"] == "checked_states":
+            for ct, enabled in enumerate(change["value"]):
+                item = widget.item(ct)
+                item.setCheckState(Qt.Checked if enabled else Qt.Unchecked)
 
 # Helper methods
 def _set_item_flag(item, flag, enabled):


### PR DESCRIPTION
It's a little circular to get this working: calling `update_display_list` a DictManager rebinds the the `displayList` variable. Since qt_list_str_widget `checked_states` is subscribed to a list comprhension involving `displayList` in the enaml view the enaml notifiers rebind `checked_states` which fires the observer `_update_enabled_check_boxes` which updates the GUI. 
